### PR TITLE
Make setUp functions in test contracts virtual

### DIFF
--- a/test/helpers/utility/MetaCoinTestSetup.sol
+++ b/test/helpers/utility/MetaCoinTestSetup.sol
@@ -8,7 +8,7 @@ import {MetaCoin} from "../../../src/examples/inheritance/MetaCoin.sol";
 contract MetaCoinTestSetup is TestStorage {
     MetaCoin public metaCoinContract;
 
-    function setUp() public {
+    function setUp() public virtual {
         vm.startPrank(owner);
         eigenPodManager = new MockEigenPodManager();
         strategyManager = new MockStrategyManager();

--- a/test/helpers/utility/ServiceManagerSetup.sol
+++ b/test/helpers/utility/ServiceManagerSetup.sol
@@ -5,7 +5,7 @@ import {Test, console} from "forge-std/Test.sol";
 import "./TestStorage.sol";
 
 contract ServiceManagerSetup is TestStorage {
-    function setUp() public {
+    function setUp() public virtual {
         vm.startPrank(owner);
         eigenPodManager = new MockEigenPodManager();
         strategyManager = new MockStrategyManager();


### PR DESCRIPTION
Functions `setUp()` must be virtual in order to override them and invoke them as such 

```
    function setUp() public override {
        super.setUp();
       // some other setup functionality here
    }
```

I overlooked this in previous changes