### PR TITLE
PRE-1670: Introduce the SimpleServiceManager contract

### DIFF
--- a/src/ServiceManager.sol
+++ b/src/ServiceManager.sol
@@ -32,57 +32,45 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
 
     mapping(address => OperatorInfo) public operators;
     mapping(address => address) public signingKeyToOperator;
-    mapping(address => mapping(string => bool)) public clientToPolicy;
+    mapping(address => mapping(string => bool)) public clientToPolicy; // DEPRECATED: use clientToPolicyID
     mapping(string => string) public idToPolicy;
     mapping(string => bool) public spentTaskIds;
-    mapping(string => string) public idToSocialGraph;
-
+    mapping(string => string) public idToSocialGraph; // DEPRECATED
     string[] public deployedPolicyIDs;
-    string[] public socialGraphIDs;
+    string[] public socialGraphIDs; // DEPRECATED
 
     address[] public strategies;
-    address public aggregator;
+    address public aggregator; // DEPRECATED
     address public delegationManager;
     address public stakeRegistry;
     address public avsDirectory;
     uint256 public thresholdStake;
 
-    mapping(string => uint256) policyIdToThreshold;
+    mapping(string => uint256) public policyIdToThreshold;
     mapping(address => bool) private permissionedOperators;
+    mapping(address => string) public clientToPolicyID;
 
     event SetPolicy(address indexed client, string indexed policyID);
     event DeployedPolicy(string indexed policyID, string policy);
-    event RemovedPolicy(address indexed client, string indexed policyID);
     event OperatorRegistered(address indexed operator);
     event OperatorRemoved(address indexed operator);
     event StrategyAdded(address indexed strategy);
     event StrategyRemoved(address indexed strategy);
-    event TaskExecuted(bytes32 indexed taskHash);
     event OperatorsStakesUpdated(address[][] indexed operatorsPerQuorum, bytes indexed quorumNumbers);
-    event NonCompliantTask(uint256 indexed taskID);
-    event AggregatorUpdated(address indexed aggregator);
     event AVSDirectoryUpdated(address indexed avsDirectory);
     event ThresholdStakeUpdated(uint256 indexed thresholdStake);
     event DelegationManagerUpdated(address indexed delegationManager);
     event StakeRegistryUpdated(address indexed stakeRegistry);
-    event SocialGraphDeployed(string indexed socialGraphID, string socialGraphConfig);
     event TaskValidated(
         address indexed msgSender,
         address indexed target,
         uint256 indexed value,
         string policyID,
         string taskId,
-        uint32 quorumThresholdCount,
+        uint256 quorumThresholdCount,
         uint256 expireByBlockNumber,
         address[] signerAddresses
     );
-
-    modifier onlyAggregator() {
-        if (msg.sender != aggregator) {
-            revert ServiceManager__Unauthorized();
-        }
-        _;
-    }
 
     modifier onlyPermissionedOperator() {
         if (!permissionedOperators[msg.sender]) {
@@ -100,7 +88,6 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
         uint256 _thresholdStake
     ) external initializer {
         _transferOwnership(_owner);
-        aggregator = _aggregator;
         delegationManager = _delegationManager;
         stakeRegistry = _stakeRegistry;
         avsDirectory = _avsDirectory;
@@ -108,16 +95,245 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
     }
 
     /**
-     * @notice Sets the aggregator address on contracts
-     * @param _aggregator is the aggregator that can execute the callback
+     * @notice Adds permissioned operators to the set for the AVS
+     * @param _operators is the address[] to be permissioned for registration on the AVS
      * @dev only callable by the owner
      */
-    function setAggregator(
-        address _aggregator
+    function addPermissionedOperators(
+        address[] calldata _operators
     ) external onlyOwner {
-        aggregator = _aggregator;
-        emit AggregatorUpdated(aggregator);
+        for (uint256 i = 0; i < _operators.length; i++) {
+            permissionedOperators[_operators[i]] = true;
+        }
     }
+
+    /**
+     * @notice Removes permissioned operators from the set for the AVS
+     * @param _operators is the address[] to have permission revoked for registration on the AVS
+     * @dev only callable by the owner
+     */
+    function removePermissionedOperators(
+        address[] calldata _operators
+    ) external onlyOwner {
+        for (uint256 i = 0; i < _operators.length; i++) {
+            permissionedOperators[_operators[i]] = false;
+        }
+    }
+
+    /**
+     * @notice Enables the rotation of Predicate Signing Key for an operator
+     * @param _oldSigningKey address of the old signing key to remove
+     * @param _newSigningKey address of the new signing key to add
+     */
+    function rotatePredicateSigningKey(address _oldSigningKey, address _newSigningKey) external {
+        require(
+            operators[msg.sender].status == OperatorStatus.REGISTERED,
+            "Predicate.rotatePredicateSigningKey: operator is not registered"
+        );
+        require(
+            msg.sender == signingKeyToOperator[_oldSigningKey],
+            "Predicate.rotatePredicateSigningKey: operator can only change it's own signing key"
+        );
+        delete signingKeyToOperator[_oldSigningKey];
+        signingKeyToOperator[_newSigningKey] = msg.sender;
+    }
+
+    /**
+     * @notice Registers a new operator
+     * @param _operatorSigningKey address of the operator signing key
+     * @param _operatorSignature signature used for validation
+     */
+    function registerOperatorToAVS(
+        address _operatorSigningKey,
+        SignatureWithSaltAndExpiry memory _operatorSignature
+    ) external {
+        require(
+            signingKeyToOperator[_operatorSigningKey] == address(0),
+            "Predicate.registerOperatorToAVS: operator already registered"
+        );
+        uint256 totalStake;
+        for (uint256 i; i != strategies.length;) {
+            totalStake += IDelegationManager(delegationManager).operatorShares(msg.sender, IStrategy(strategies[i]));
+            unchecked {
+                ++i;
+            }
+        }
+
+        if (totalStake >= thresholdStake) {
+            operators[msg.sender] = OperatorInfo(totalStake, OperatorStatus.REGISTERED);
+            signingKeyToOperator[_operatorSigningKey] = msg.sender;
+            ISignatureUtils.SignatureWithSaltAndExpiry memory _operatorSig = ISignatureUtils.SignatureWithSaltAndExpiry(
+                _operatorSignature.signature, _operatorSignature.salt, _operatorSignature.expiry
+            );
+            IAVSDirectory(avsDirectory).registerOperatorToAVS(msg.sender, _operatorSig);
+            emit OperatorRegistered(msg.sender);
+        }
+    }
+
+    /**
+     * @notice Removes an operator
+     * @param _operator the address of the operator to be removed
+     */
+    function deregisterOperatorFromAVS(
+        address _operator
+    ) external onlyOwner {
+        require(
+            operators[_operator].status != OperatorStatus.NEVER_REGISTERED,
+            "Predicate.deregisterOperatorFromAVS: operator is not registered"
+        );
+        operators[_operator] = OperatorInfo(0, OperatorStatus.DEREGISTERED);
+        IAVSDirectory(avsDirectory).deregisterOperatorFromAVS(_operator);
+        emit OperatorRemoved(_operator);
+    }
+
+    /**
+     * @notice Deploys a policy for which clients can use
+     * @param _policyID is a unique identifier
+     * @param _policy is set of formatted rules
+     * @param _quorumThreshold is the number of signatures required to validate a task
+     */
+    function deployPolicy(
+        string memory _policyID,
+        string memory _policy,
+        uint256 _quorumThreshold
+    ) external onlyOwner {
+        require(bytes(idToPolicy[_policyID]).length == 0, "Predicate.deployPolicy: policy exists");
+        idToPolicy[_policyID] = _policy;
+        policyIdToThreshold[_policyID] = _quorumThreshold;
+        deployedPolicyIDs.push(_policyID);
+        emit DeployedPolicy(_policyID, _policy);
+    }
+
+    /**
+     * @notice Gets array of deployed policies
+     * @return array of deployed policies
+     */
+    function getDeployedPolicies() external view returns (string[] memory) {
+        return deployedPolicyIDs;
+    }
+
+    /**
+     * @notice Sets a policy for the calling contract (msg.sender)
+     * @dev Associates a client contract with a specific policy ID. The policy must be previously registered.
+     * @param _policyID Identifier of a registered policy to associate with the caller
+     */
+    function setPolicy(
+        string memory _policyID
+    ) external {
+        clientToPolicyID[msg.sender] = _policyID;
+        emit SetPolicy(msg.sender, _policyID);
+    }
+
+    /**
+     * @notice Overrides the policy for a specific client address
+     * @param _policyID is the unique identifier for the policy
+     * @param _clientAddress is the address of the client for which the policy is being overridden
+     */
+    function overrideClientPolicyID(string memory _policyID, address _clientAddress) external onlyOwner {
+        require(bytes(_policyID).length > 0, "SimplePredicate.setPolicy: policy ID cannot be empty");
+        clientToPolicyID[_clientAddress] = _policyID;
+        emit SetPolicy(_clientAddress, _policyID);
+    }
+
+    /**
+     * @notice Performs the hashing of an STM task
+     * @param _task parameters of the task
+     * @return the keccak256 digest of the task
+     */
+    function hashTaskWithExpiry(
+        Task calldata _task
+    ) public pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _task.taskId,
+                _task.msgSender,
+                _task.target,
+                _task.value,
+                _task.encodedSigAndArgs,
+                _task.policyID,
+                _task.quorumThresholdCount,
+                _task.expireByBlockNumber
+            )
+        );
+    }
+
+    /**
+     * @notice Computes a secure task hash with validation-time context
+     * @param _task The task parameters to hash
+     * @return bytes32 The keccak256 digest including validation context
+     */
+    function hashTaskSafe(
+        Task calldata _task
+    ) public view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _task.taskId,
+                _task.msgSender,
+                msg.sender,
+                _task.value,
+                _task.encodedSigAndArgs,
+                _task.policyID,
+                _task.quorumThresholdCount,
+                _task.expireByBlockNumber
+            )
+        );
+    }
+
+    /**
+     * @notice Validates signatures using the OpenZeppelin ECDSA library for the Predicate Single Transaction Model
+     * @param _task the params of the task
+     * @param  signerAddresses the addresses of the operators
+     * @param  signatures the signatures of the operators
+     */
+    function validateSignatures(
+        Task calldata _task,
+        address[] memory signerAddresses,
+        bytes[] memory signatures
+    ) external returns (bool isVerified) {
+        require(_task.quorumThresholdCount != 0, "Predicate.validateSignatures: quorum threshold count cannot be zero");
+        require(
+            signerAddresses.length == signatures.length,
+            "Predicate.validateSignatures: Mismatch between signers and signatures"
+        );
+        require(block.number <= _task.expireByBlockNumber, "Predicate.validateSignatures: transaction expired");
+        require(!spentTaskIds[_task.taskId], "Predicate.validateSignatures: task ID already spent");
+
+        uint256 numSignaturesRequired = policyIdToThreshold[_task.policyID];
+        require(
+            numSignaturesRequired != 0 && _task.quorumThresholdCount == numSignaturesRequired,
+            "Predicate.PredicateVerified: deployed policy quorum threshold differs from task quorum threshold"
+        );
+
+        bytes32 messageHash = hashTaskSafe(_task);
+        for (uint256 i = 0; i < numSignaturesRequired;) {
+            if (i > 0 && uint160(signerAddresses[i]) <= uint160(signerAddresses[i - 1])) {
+                revert("Predicate.validateSignatures: Signer addresses must be unique and sorted");
+            }
+            address recoveredSigner = ECDSA.recover(messageHash, signatures[i]);
+            require(recoveredSigner == signerAddresses[i], "Predicate.validateSignatures: Invalid signature");
+            address operator = signingKeyToOperator[recoveredSigner];
+            require(operators[operator].status == OperatorStatus.REGISTERED, "Signer is not a registered operator");
+            unchecked {
+                ++i;
+            }
+        }
+
+        emit TaskValidated(
+            _task.msgSender,
+            _task.target,
+            _task.value,
+            _task.policyID,
+            _task.taskId,
+            _task.quorumThresholdCount,
+            _task.expireByBlockNumber,
+            signerAddresses
+        );
+
+        spentTaskIds[_task.taskId] = true;
+        return true;
+    }
+
+    // ============ EigenLayer ============ //
 
     /**
      * @notice Sets the delegationManager contract address
@@ -176,221 +392,6 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
         string memory _metadataURI
     ) external onlyOwner {
         IAVSDirectory(avsDirectory).updateAVSMetadataURI(_metadataURI);
-    }
-
-    /**
-     * @notice Adds permissioned operators to the set for the AVS
-     * @param _operators is the address[] to be permissioned for registration on the AVS
-     * @dev only callable by the owner
-     */
-    function addPermissionedOperators(
-        address[] calldata _operators
-    ) external onlyOwner {
-        for (uint256 i = 0; i < _operators.length; i++) {
-            permissionedOperators[_operators[i]] = true;
-        }
-    }
-
-    /**
-     * @notice Removes permissioned operators from the set for the AVS
-     * @param _operators is the address[] to have permission revoked for registration on the AVS
-     * @dev only callable by the owner
-     */
-    function removePermissionedOperators(
-        address[] calldata _operators
-    ) external onlyOwner {
-        for (uint256 i = 0; i < _operators.length; i++) {
-            permissionedOperators[_operators[i]] = false;
-        }
-    }
-
-    /**
-     * @notice Enables the rotation of Predicate Signing Key for an operator
-     * @param _oldSigningKey address of the old signing key to remove
-     * @param _newSigningKey address of the new signing key to add
-     */
-    function rotatePredicateSigningKey(address _oldSigningKey, address _newSigningKey) external {
-        require(
-            operators[msg.sender].status == OperatorStatus.REGISTERED,
-            "ServiceManager.rotatePredicateSigningKey: operator is not registered"
-        );
-        require(
-            msg.sender == signingKeyToOperator[_oldSigningKey],
-            "ServiceManager.rotatePredicateSigningKey: operator can only change it's own signing key"
-        );
-        delete signingKeyToOperator[_oldSigningKey];
-        signingKeyToOperator[_newSigningKey] = msg.sender;
-    }
-
-    /**
-     * @notice Registers a new operator
-     * @param _operatorSigningKey address of the operator signing key
-     * @param _operatorSignature signature used for validation
-     */
-    function registerOperatorToAVS(
-        address _operatorSigningKey,
-        SignatureWithSaltAndExpiry memory _operatorSignature
-    ) external {
-        require(
-            signingKeyToOperator[_operatorSigningKey] == address(0),
-            "ServiceManager.registerOperatorToAVS: operator already registered"
-        );
-        uint256 totalStake;
-        for (uint256 i; i != strategies.length;) {
-            totalStake += IDelegationManager(delegationManager).operatorShares(msg.sender, IStrategy(strategies[i]));
-            unchecked {
-                ++i;
-            }
-        }
-
-        if (totalStake >= thresholdStake) {
-            operators[msg.sender] = OperatorInfo(totalStake, OperatorStatus.REGISTERED);
-            signingKeyToOperator[_operatorSigningKey] = msg.sender;
-            ISignatureUtils.SignatureWithSaltAndExpiry memory _operatorSig = ISignatureUtils.SignatureWithSaltAndExpiry(
-                _operatorSignature.signature, _operatorSignature.salt, _operatorSignature.expiry
-            );
-            IAVSDirectory(avsDirectory).registerOperatorToAVS(msg.sender, _operatorSig);
-            emit OperatorRegistered(msg.sender);
-        }
-    }
-
-    /**
-     * @notice Removes an operator
-     * @param _operator the address of the operator to be removed
-     */
-    function deregisterOperatorFromAVS(
-        address _operator
-    ) external onlyOwner {
-        require(
-            operators[_operator].status != OperatorStatus.NEVER_REGISTERED,
-            "ServiceManager.deregisterOperatorFromAVS: operator is not registered"
-        );
-        operators[_operator] = OperatorInfo(0, OperatorStatus.DEREGISTERED);
-        IAVSDirectory(avsDirectory).deregisterOperatorFromAVS(_operator);
-        emit OperatorRemoved(_operator);
-    }
-
-    /**
-     * @notice Deploys a policy for which clients can use
-     * @param _policyID is a unique identifier
-     * @param _policy is set of formatted rules
-     * @param _quorumThreshold is the number of signatures required to validate a task
-     */
-    function deployPolicy(
-        string memory _policyID,
-        string memory _policy,
-        uint256 _quorumThreshold
-    ) external onlyOwner {
-        require(bytes(idToPolicy[_policyID]).length == 0, "ServiceManager.deployPolicy: policy exists");
-        idToPolicy[_policyID] = _policy;
-        policyIdToThreshold[_policyID] = _quorumThreshold;
-        deployedPolicyIDs.push(_policyID);
-        emit DeployedPolicy(_policyID, _policy);
-    }
-
-    /**
-     * @notice Deploys a social graph which clients can use in policy
-     * @param _socialGraphID is a unique identifier
-     * @param _socialGraphConfig is the config for the social graph
-     */
-    function deploySocialGraph(string memory _socialGraphID, string memory _socialGraphConfig) external onlyOwner {
-        require(
-            bytes(idToSocialGraph[_socialGraphID]).length == 0, "ServiceManager.deploySocialGraph: social graph exists"
-        );
-        idToSocialGraph[_socialGraphID] = _socialGraphConfig;
-        socialGraphIDs.push(_socialGraphID);
-        emit SocialGraphDeployed(_socialGraphID, _socialGraphConfig);
-    }
-
-    /**
-     * @notice Gets array of deployed policies
-     * @return array of deployed policies
-     */
-    function getDeployedPolicies() external view returns (string[] memory) {
-        return deployedPolicyIDs;
-    }
-
-    /**
-     * @notice Gets array of social graph IDs
-     * @return array of social graph IDs
-     */
-    function getSocialGraphIDs() external view returns (string[] memory) {
-        return socialGraphIDs;
-    }
-
-    /**
-     * @notice Sets a policy for a client
-     * @param _policyID address of the Pod
-     */
-    function setPolicy(
-        string memory _policyID
-    ) external {
-        clientToPolicy[msg.sender][_policyID] = true;
-        emit SetPolicy(msg.sender, _policyID);
-    }
-
-    /**
-     * @notice Removes a policy for a client
-     * @param _policyID address of the Pod
-     */
-    function removePolicy(
-        string memory _policyID
-    ) external {
-        clientToPolicy[msg.sender][_policyID] = false;
-        emit RemovedPolicy(msg.sender, _policyID);
-    }
-
-    /**
-     * @notice Validates signatures using the OpenZeppelin ECDSA library for the Predicate Single Transaction Model
-     * @param _task the params of the task
-     * @param  signerAddresses the addresses of the operators
-     * @param  signatures the signatures of the operators
-     */
-    function validateSignatures(
-        Task calldata _task,
-        address[] memory signerAddresses,
-        bytes[] memory signatures
-    ) external returns (bool isVerified) {
-        require(
-            _task.quorumThresholdCount != 0, "ServiceManager.PredicateVerified: quorum threshold count cannot be zero"
-        );
-        require(signerAddresses.length == signatures.length, "Mismatch between signers and signatures");
-        require(block.number <= _task.expireByBlockNumber, "ServiceManager.PredicateVerified: transaction expired");
-        require(!spentTaskIds[_task.taskId], "ServiceManager.PredicateVerified: task ID already spent");
-
-        uint256 quorumThreshold = policyIdToThreshold[_task.policyID];
-        require(
-            quorumThreshold != 0 && _task.quorumThresholdCount == quorumThreshold,
-            "ServiceManager.PredicateVerified: deployed policy quorum threshold differs from task quorum threshold"
-        );
-
-        bytes32 messageHash = hashTaskWithExpiry(_task);
-        for (uint256 i = 0; i < _task.quorumThresholdCount;) {
-            if (i > 0 && uint160(signerAddresses[i]) <= uint160(signerAddresses[i - 1])) {
-                revert("Signer addresses must be unique and sorted");
-            }
-            address recoveredSigner = ECDSA.recover(messageHash, signatures[i]);
-            require(recoveredSigner == signerAddresses[i], "Invalid signature");
-            address operator = signingKeyToOperator[recoveredSigner];
-            require(operators[operator].status == OperatorStatus.REGISTERED, "Signer is not a registered operator");
-            unchecked {
-                ++i;
-            }
-        }
-
-        emit TaskValidated(
-            _task.msgSender,
-            _task.target,
-            _task.value,
-            _task.policyID,
-            _task.taskId,
-            _task.quorumThresholdCount,
-            _task.expireByBlockNumber,
-            signerAddresses
-        );
-
-        spentTaskIds[_task.taskId] = true;
-        return true;
     }
 
     /**
@@ -506,27 +507,5 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
             }
         }
         emit OperatorsStakesUpdated(operatorsPerQuorum, quorumNumbers);
-    }
-
-    /**
-     * @notice Performs the hashing of an STM task
-     * @param _task parameters of the task
-     * @return the keccak256 digest of the task
-     */
-    function hashTaskWithExpiry(
-        Task calldata _task
-    ) public pure returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                _task.taskId,
-                _task.msgSender,
-                _task.target,
-                _task.value,
-                _task.encodedSigAndArgs,
-                _task.policyID,
-                _task.quorumThresholdCount,
-                _task.expireByBlockNumber
-            )
-        );
     }
 }

--- a/src/ServiceManager.sol
+++ b/src/ServiceManager.sol
@@ -198,6 +198,7 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
         uint256 _quorumThreshold
     ) external onlyOwner {
         require(bytes(idToPolicy[_policyID]).length == 0, "Predicate.deployPolicy: policy exists");
+        require(_quorumThreshold > 0, "Predicate.deployPolicy: quorum threshold must be greater than zero");
         idToPolicy[_policyID] = _policy;
         policyIdToThreshold[_policyID] = _quorumThreshold;
         deployedPolicyIDs.push(_policyID);
@@ -220,6 +221,8 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
     function setPolicy(
         string memory _policyID
     ) external {
+        require(bytes(_policyID).length > 0, "Predicate.setPolicy: policy ID cannot be empty");
+        require(policyIdToThreshold[_policyID] > 0, "Predicate.setPolicy: policy ID not registered");
         clientToPolicyID[msg.sender] = _policyID;
         emit SetPolicy(msg.sender, _policyID);
     }
@@ -230,7 +233,8 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
      * @param _clientAddress is the address of the client for which the policy is being overridden
      */
     function overrideClientPolicyID(string memory _policyID, address _clientAddress) external onlyOwner {
-        require(bytes(_policyID).length > 0, "SimplePredicate.setPolicy: policy ID cannot be empty");
+        require(bytes(_policyID).length > 0, "Predicate.setPolicy: policy ID cannot be empty");
+        require(policyIdToThreshold[_policyID] > 0, "Predicate.setPolicy: policy ID not registered");
         clientToPolicyID[_clientAddress] = _policyID;
         emit SetPolicy(_clientAddress, _policyID);
     }

--- a/src/SimpleServiceManager.sol
+++ b/src/SimpleServiceManager.sol
@@ -92,7 +92,11 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
      * @param _signingKeys Corresponding signing keys for the operators
      * @param _removeOperators Array of operator addresses to remove
      */
-    function syncOperators(address[] calldata _registrationKeys, address[] calldata _signingKeys, address[] calldata _removeOperators) external onlyOwner {
+    function syncOperators(
+        address[] calldata _registrationKeys,
+        address[] calldata _signingKeys,
+        address[] calldata _removeOperators
+    ) external onlyOwner {
         require(
             _registrationKeys.length == _signingKeys.length,
             "Predicate.syncOperators: registration and signing keys length mismatch"
@@ -113,29 +117,29 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
         }
 
         for (uint256 i = 0; i < _registrationKeys.length;) {
-                address registrationKey = _registrationKeys[i];
-                address signingKey = _signingKeys[i];
+            address registrationKey = _registrationKeys[i];
+            address signingKey = _signingKeys[i];
 
-                bool isExistingOperator = EnumerableSet.contains(registeredOperators, registrationKey);
+            bool isExistingOperator = EnumerableSet.contains(registeredOperators, registrationKey);
 
-                if (isExistingOperator) {
-                    if (operatorAddressToSigningKey[registrationKey] != signingKey) {
-                        operatorAddressToSigningKey[registrationKey] = signingKey;
-                        emit OperatorUpdated(registrationKey, signingKey);
-                    }
-                    unchecked {
-                        ++i;
-                    }
-                    continue;
+            if (isExistingOperator) {
+                if (operatorAddressToSigningKey[registrationKey] != signingKey) {
+                    operatorAddressToSigningKey[registrationKey] = signingKey;
+                    emit OperatorUpdated(registrationKey, signingKey);
                 }
-
-                EnumerableSet.add(registeredOperators, registrationKey);
-                signingKeyToOperatorAddress[signingKey] = registrationKey;
-                operatorAddressToSigningKey[registrationKey] = signingKey;
-                emit OperatorRegistered(registrationKey);
-
                 unchecked {
                     ++i;
+                }
+                continue;
+            }
+
+            EnumerableSet.add(registeredOperators, registrationKey);
+            signingKeyToOperatorAddress[signingKey] = registrationKey;
+            operatorAddressToSigningKey[registrationKey] = signingKey;
+            emit OperatorRegistered(registrationKey);
+
+            unchecked {
+                ++i;
             }
         }
     }
@@ -155,8 +159,7 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
      */
     function syncPolicies(string[] calldata policyIDs, uint32[] calldata thresholds) external onlyOwner {
         require(
-            policyIDs.length == thresholds.length,
-            "Predicate.syncPolicies: policy IDs and thresholds length mismatch"
+            policyIDs.length == thresholds.length, "Predicate.syncPolicies: policy IDs and thresholds length mismatch"
         );
 
         for (uint256 i = 0; i < policyIDs.length;) {

--- a/src/SimpleServiceManager.sol
+++ b/src/SimpleServiceManager.sol
@@ -12,9 +12,11 @@ import {ISimpleServiceManager} from "./interfaces/ISimpleServiceManager.sol";
 
 contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUpgradeable {
     event SetPolicy(address indexed client, string indexed policyID);
-    event PolicyDeployed(string indexed policyID);
+    event PolicySynced(string indexed policyID);
+    event PolicySyncedSkipped(string indexed policyID);
     event OperatorRegistered(address indexed operator);
     event OperatorRemoved(address indexed operator);
+    event OperatorUpdated(address indexed operator, address indexed signingKey);
 
     event TaskValidated(
         address indexed msgSender,
@@ -75,8 +77,10 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
                 bool isExistingOperator = EnumerableSet.contains(registeredOperators, registrationKey);
 
                 if (isExistingOperator) {
-                    if (operatorAddressToSigningKey[registrationKey] != signingKey)
+                    if (operatorAddressToSigningKey[registrationKey] != signingKey) {
                         operatorAddressToSigningKey[registrationKey] = signingKey;
+                        emit OperatorUpdated(registrationKey, signingKey);
+                    }
                     unchecked {
                         ++i;
                     }
@@ -121,9 +125,10 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
             if (policyIDToThreshold[policyIDs[i]] == 0) {
                 policyIDToThreshold[policyIDs[i]] = thresholds[i];
                 deployedPolicyIDs.push(policyIDs[i]);
-                emit PolicyDeployed(policyIDs[i]);
+                emit PolicySynced(policyIDs[i]);
             }
 
+            emit PolicySyncedSkipped(policyIDs[i]);
             unchecked {
                 ++i;
             }

--- a/src/SimpleServiceManager.sol
+++ b/src/SimpleServiceManager.sol
@@ -24,7 +24,7 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
     /**
      * @notice Emitted when a policy sync is skipped due to existing registration
      */
-    event PolicySyncedSkipped(string indexed policyID);
+    event PolicySyncSkipped(string indexed policyID);
 
     /**
      * @notice Emitted when a new operator is registered
@@ -172,7 +172,7 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
                 emit PolicySynced(policyIDs[i]);
             }
 
-            emit PolicySyncedSkipped(policyIDs[i]);
+            emit PolicySyncSkipped(policyIDs[i]);
             unchecked {
                 ++i;
             }

--- a/src/SimpleServiceManager.sol
+++ b/src/SimpleServiceManager.sol
@@ -11,13 +11,39 @@ import {Task, SignatureWithSaltAndExpiry} from "./interfaces/IPredicateManager.s
 import {ISimpleServiceManager} from "./interfaces/ISimpleServiceManager.sol";
 
 contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUpgradeable {
+    /**
+     * @notice Emitted when a policy is set for a client
+     */
     event SetPolicy(address indexed client, string indexed policyID);
+
+    /**
+     * @notice Emitted when a new policy is successfully synced
+     */
     event PolicySynced(string indexed policyID);
+
+    /**
+     * @notice Emitted when a policy sync is skipped due to existing registration
+     */
     event PolicySyncedSkipped(string indexed policyID);
+
+    /**
+     * @notice Emitted when a new operator is registered
+     */
     event OperatorRegistered(address indexed operator);
+
+    /**
+     * @notice Emitted when an operator is removed
+     */
     event OperatorRemoved(address indexed operator);
+
+    /**
+     * @notice Emitted when an operator's signing key is updated
+     */
     event OperatorUpdated(address indexed operator, address indexed signingKey);
 
+    /**
+     * @notice Emitted when a task is successfully validated
+     */
     event TaskValidated(
         address indexed msgSender,
         address indexed target,
@@ -29,15 +55,31 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
         address[] signerAddresses
     );
 
+    /// @dev Set of currently registered operator addresses
     EnumerableSet.AddressSet private registeredOperators;
+
+    /// @notice Maps a signing key to its associated operator address
     mapping(address => address) public signingKeyToOperatorAddress;
+
+    /// @notice Maps an operator address to its associated signing key
     mapping(address => address) public operatorAddressToSigningKey;
 
+    /// @notice Tracks spent task IDs to prevent replay attacks
     mapping(string => bool) public spentTaskIDs;
+
+    /// @notice Maps client contract addresses to their assigned policy ID
     mapping(address => string) public clientToPolicyID;
+
+    /// @notice Maps policy IDs to their configured quorum threshold
     mapping(string => uint256) public policyIDToThreshold;
+
+    /// @notice List of all deployed policy IDs
     string[] public deployedPolicyIDs;
 
+    /**
+     * @notice Initializes the contract and transfers ownership.
+     * @param _owner Address to set as the contract owner.
+     */
     function initialize(
         address _owner
     ) external initializer {
@@ -45,10 +87,10 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
     }
 
     /**
-     * @notice Adds, deletes, or updates operator registration and signing keys
-     * @param _registrationKeys is an array of registration keys for operators
-     * @param _signingKeys is an array of signing keys corresponding to the registration keys
-     * @param _removeOperators is an array of operator addresses to be removed
+     * @notice Registers, updates, or removes operators and their signing keys
+     * @param _registrationKeys Array of operator addresses to register or update
+     * @param _signingKeys Corresponding signing keys for the operators
+     * @param _removeOperators Array of operator addresses to remove
      */
     function syncOperators(address[] calldata _registrationKeys, address[] calldata _signingKeys, address[] calldata _removeOperators) external onlyOwner {
         require(
@@ -99,8 +141,8 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
     }
 
     /**
-     * @notice Gets array of deployed policies
-     * @return array of deployed policies
+     * @notice Returns all deployed policy IDs
+     * @return Array of deployed policy IDs
      */
     function getDeployedPolicyIDs() external view returns (string[] memory) {
         return deployedPolicyIDs;
@@ -108,9 +150,8 @@ contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUp
 
     /**
      * @notice Registers or updates policy IDs with their associated quorum thresholds
-     * @dev Adds policies to the deployedPolicyIDs array and sets their thresholds
-     * @param policyIDs Array of unique policy identifiers to register
-     * @param thresholds Array of quorum thresholds corresponding to each policy ID
+     * @param policyIDs Array of policy identifiers
+     * @param thresholds Corresponding quorum thresholds for each policy
      */
     function syncPolicies(string[] calldata policyIDs, uint32[] calldata thresholds) external onlyOwner {
         require(

--- a/src/SimpleServiceManager.sol
+++ b/src/SimpleServiceManager.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {OwnableUpgradeable} from "openzeppelin-upgradeable/access/OwnableUpgradeable.sol";
+import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
+
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
+import {Task, SignatureWithSaltAndExpiry} from "./interfaces/IPredicateManager.sol";
+import {ISimpleServiceManager} from "./interfaces/ISimpleServiceManager.sol";
+
+contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUpgradeable {
+    event SetPolicy(address indexed client, string indexed policyID);
+    event PolicyDeployed(string indexed policyID, string policy);
+    event OperatorRegistered(address indexed operator);
+    event OperatorRemoved(address indexed operator);
+
+    event TaskValidated(
+        address indexed msgSender,
+        address indexed target,
+        uint256 indexed value,
+        string policyID,
+        string taskId,
+        uint256 quorumThresholdCount,
+        uint256 expireByBlockNumber,
+        address[] signerAddresses
+    );
+
+    EnumerableSet.AddressSet private registeredOperators;
+    mapping(address => address) public signingKeyToOperatorAddress;
+    mapping(address => address) public operatorAddressToSigningKey;
+
+    mapping(string => bool) public spentTaskIDs;
+    mapping(address => string) public clientToPolicyID;
+    mapping(string => uint256) public policyIDToThreshold;
+    string[] public deployedPolicyIDs;
+
+    function initialize(
+        address _owner
+    ) external initializer {
+        _transferOwnership(_owner);
+    }
+
+    /**
+     * @notice Updates the operator registration and signing keys by adding or removing operators and updating signing keys.
+     * @param _registrationKeys is an array of registration keys for operators
+     * @param _signingKeys is an array of signing keys corresponding to the registration keys
+     */
+    function syncOperators(address[] calldata _registrationKeys, address[] calldata _signingKeys) external onlyOwner {
+        require(
+            _registrationKeys.length == _signingKeys.length,
+            "SimpleServiceManager.syncOperators: registration and signing keys length mismatch"
+        );
+
+        uint256 operatorCount = EnumerableSet.length(registeredOperators);
+        for (uint256 i = 0; i < operatorCount;) {
+            address operator = EnumerableSet.at(registeredOperators, 0);
+            address signingKey = operatorAddressToSigningKey[operator];
+
+            delete operatorAddressToSigningKey[operator];
+            delete signingKeyToOperatorAddress[signingKey];
+
+            EnumerableSet.remove(registeredOperators, operator);
+            emit OperatorRemoved(operator);
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        for (uint256 i = 0; i < _registrationKeys.length;) {
+            address registrationKey = _registrationKeys[i];
+            address signingKey = _signingKeys[i];
+
+            require(
+                signingKeyToOperatorAddress[signingKey] == address(0),
+                "SimpleServiceManager.syncOperators: signing key already associated with an operator"
+            );
+
+            signingKeyToOperatorAddress[signingKey] = registrationKey;
+            operatorAddressToSigningKey[registrationKey] = signingKey;
+
+            EnumerableSet.add(registeredOperators, registrationKey);
+            emit OperatorRegistered(registrationKey);
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Gets array of deployed policies
+     * @return array of deployed policies
+     */
+    function getDeployedPolicyIDs() external view returns (string[] memory) {
+        return deployedPolicyIDs;
+    }
+
+    /**
+     * @notice Registers or updates policy IDs with their associated quorum thresholds
+     * @dev Adds policies to the deployedPolicyIDs array and sets their thresholds
+     * @param policyIDs Array of unique policy identifiers to register
+     * @param thresholds Array of quorum thresholds corresponding to each policy ID
+     */
+    function syncPolicies(string[] calldata policyIDs, uint32[] calldata thresholds) external onlyOwner {
+        require(
+            policyIDs.length == thresholds.length,
+            "SimpleServiceManager.syncPolicies: policy IDs and thresholds length mismatch"
+        );
+
+        for (uint256 i = 0; i < policyIDs.length;) {
+            require(bytes(policyIDs[i]).length > 0, "SimpleServiceManager.syncPolicies: policy ID cannot be empty");
+
+            require(thresholds[i] > 0, "SimpleServiceManager.syncPolicies: threshold must be greater than zero");
+
+            policyIDToThreshold[policyIDs[i]] = thresholds[i];
+            deployedPolicyIDs.push(policyIDs[i]);
+            emit PolicyDeployed(policyIDs[i], "");
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @notice Sets a policy for the calling contract (msg.sender)
+     * @dev Associates a client contract with a specific policy ID. The policy must be previously registered.
+     * @param _policyID Identifier of a registered policy to associate with the caller
+     */
+    function setPolicy(
+        string memory _policyID
+    ) external {
+        require(bytes(_policyID).length > 0, "SimpleServiceManager.setPolicy: policy ID cannot be empty");
+        require(policyIDToThreshold[_policyID] > 0, "SimpleServiceManager.setPolicy: policy ID not registered");
+        clientToPolicyID[msg.sender] = _policyID;
+        emit SetPolicy(msg.sender, _policyID);
+    }
+
+    /**
+     * @notice Overrides the policy for a specific client address
+     * @param _policyID is the unique identifier for the policy
+     * @param _clientAddress is the address of the client for which the policy is being overridden
+     */
+    function overrideClientPolicyID(string memory _policyID, address _clientAddress) external onlyOwner {
+        require(bytes(_policyID).length > 0, "SimpleServiceManager.setPolicy: policy ID cannot be empty");
+        clientToPolicyID[_clientAddress] = _policyID;
+        emit SetPolicy(_clientAddress, _policyID);
+    }
+
+    /**
+     * @notice Computes a secure task hash with validation-time context
+     * @param _task The task parameters to hash
+     * @return bytes32 The keccak256 digest including validation context
+     */
+    function hashTaskSafe(
+        Task calldata _task
+    ) public view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                _task.taskId,
+                _task.msgSender,
+                msg.sender,
+                _task.value,
+                _task.encodedSigAndArgs,
+                _task.policyID,
+                _task.quorumThresholdCount,
+                _task.expireByBlockNumber
+            )
+        );
+    }
+
+    /**
+     * @notice Validates signatures using the OpenZeppelin ECDSA library for the Predicate Single Transaction Model
+     * @param _task the params of the task
+     * @param  signerAddresses the addresses of the operators
+     * @param  signatures the signatures of the operators
+     */
+    function validateSignatures(
+        Task calldata _task,
+        address[] memory signerAddresses,
+        bytes[] memory signatures
+    ) external returns (bool isVerified) {
+        require(_task.quorumThresholdCount != 0, "Predicate.validateSignatures: quorum threshold count cannot be zero");
+        require(
+            signerAddresses.length == signatures.length,
+            "Predicate.validateSignatures: Mismatch between signers and signatures"
+        );
+        require(block.number <= _task.expireByBlockNumber, "Predicate.validateSignatures: transaction expired");
+        require(!spentTaskIDs[_task.taskId], "Predicate.validateSignatures: task ID already spent");
+
+        uint256 numSignaturesRequired = policyIDToThreshold[_task.policyID];
+        require(
+            numSignaturesRequired != 0 && _task.quorumThresholdCount == numSignaturesRequired,
+            "Predicate.PredicateVerified: deployed policy quorum threshold differs from task quorum threshold"
+        );
+
+        bytes32 messageHash = hashTaskSafe(_task);
+        for (uint256 i = 0; i < numSignaturesRequired;) {
+            if (i > 0 && uint160(signerAddresses[i]) <= uint160(signerAddresses[i - 1])) {
+                revert("Predicate.validateSignatures: Signer addresses must be unique and sorted");
+            }
+            address recoveredSigner = ECDSA.recover(messageHash, signatures[i]);
+            require(recoveredSigner == signerAddresses[i], "Predicate.validateSignatures: Invalid signature");
+            require(
+                signingKeyToOperatorAddress[recoveredSigner] != address(0),
+                "Predicate.validateSignatures: Signer is not a registered operator"
+            );
+            unchecked {
+                ++i;
+            }
+        }
+
+        emit TaskValidated(
+            _task.msgSender,
+            _task.target,
+            _task.value,
+            _task.policyID,
+            _task.taskId,
+            _task.quorumThresholdCount,
+            _task.expireByBlockNumber,
+            signerAddresses
+        );
+
+        spentTaskIDs[_task.taskId] = true;
+        return true;
+    }
+}

--- a/src/interfaces/IPredicateManager.sol
+++ b/src/interfaces/IPredicateManager.sol
@@ -38,14 +38,6 @@ struct SignatureWithSaltAndExpiry {
  */
 interface IPredicateManager {
     /**
-     * @notice Sets the metadata URI for the AVS
-     * @param _metadataURI is the metadata URI for the AVS
-     */
-    function setMetadataURI(
-        string memory _metadataURI
-    ) external;
-
-    /**
      * @notice Forwards a call to EigenLayer's DelegationManager contract to confirm operator registration with the AVS
      * @param operatorSigningKey The address of the operator's signing key.
      * @param operatorSignature The signature, salt, and expiry of the operator's signature.
@@ -64,41 +56,12 @@ interface IPredicateManager {
     ) external;
 
     /**
-     * @notice Returns the list of strategies that the operator has potentially restaked on the AVS
-     * @param operator The address of the operator to get restaked strategies for
-     * @dev This function is intended to be called off-chain
-     * @dev No guarantee is made on whether the operator has shares for a strategy in a quorum or uniqueness
-     *      of each element in the returned array. The off-chain service should do that validation separately
-     */
-    function getOperatorRestakedStrategies(
-        address operator
-    ) external view returns (address[] memory);
-
-    /**
-     * @notice Returns the list of strategies that the AVS supports for restaking
-     * @dev This function is intended to be called off-chain
-     * @dev No guarantee is made on uniqueness of each element in the returned array.
-     *      The off-chain service should do that validation separately
-     */
-    function getRestakeableStrategies() external view returns (address[] memory);
-
-    /**
      * @notice Sets a policy ID for the sender, defining execution rules or parameters for tasks
      * @param policyID string pointing to the policy details
      * @dev Only callable by client contracts or EOAs to associate a policy with their address
      * @dev Emits a SetPolicy event upon successful association
      */
     function setPolicy(
-        string memory policyID
-    ) external;
-
-    /**
-     * @notice Removes a policy ID for the sender, removing execution rules or parameters for tasks
-     * @param policyID string pointing to the policy details
-     * @dev Only callable by client contracts or EOAs to disassociate a policy with their address
-     * @dev Emits a RemovedPolicy event upon successful association
-     */
-    function removePolicy(
         string memory policyID
     ) external;
 
@@ -118,20 +81,6 @@ interface IPredicateManager {
     function getDeployedPolicies() external view returns (string[] memory);
 
     /**
-     * @notice Deploys a social graph which clients can use in policy
-     * @param _socialGraphID is a unique identifier
-     * @param _socialGraphConfig is the config for the social graph
-     * @dev Only callable by service manager deployer
-     * @dev Emits a SocialGraphDeployed event upon successful deployment
-     */
-    function deploySocialGraph(string memory _socialGraphID, string memory _socialGraphConfig) external;
-
-    /**
-     * @notice Returns the list of social graph IDs that the AVS supports
-     */
-    function getSocialGraphIDs() external view returns (string[] memory);
-
-    /**
      * @notice Verifies if a task is authorized by the required number of operators
      * @param _task Parameters of the task including sender, target, function signature, arguments, quorum count, and expiry block
      * @param signerAddresses Array of addresses of the operators who signed the task
@@ -144,28 +93,6 @@ interface IPredicateManager {
         address[] memory signerAddresses,
         bytes[] memory signatures
     ) external returns (bool isVerified);
-
-    /**
-     * @notice Adds a new strategy to the Service Manager
-     * @dev Only callable by the contract owner. Adds a strategy that operators can stake on.
-     * @param _strategy The address of the strategy contract to add
-     * @param quorumNumber The quorum number associated with the strategy
-     * @param index The index of the strategy within the quorum
-     * @dev Emits a StrategyAdded event upon successful addition of the strategy
-     * @dev Reverts if the strategy does not exist or is already added
-     */
-    function addStrategy(address _strategy, uint8 quorumNumber, uint256 index) external;
-
-    /**
-     * @notice Removes an existing strategy from the Service Manager
-     * @dev Only callable by the contract owner. Removes a strategy that operators are currently able to stake on.
-     * @param _strategy The address of the strategy contract to remove
-     * @dev Emits a StrategyRemoved event upon successful removal of the strategy
-     * @dev Reverts if the strategy is not currently added or if the address is invalid
-     */
-    function removeStrategy(
-        address _strategy
-    ) external;
 
     /**
      * @notice Enables the rotation of Predicate Signing Key for an operator

--- a/src/interfaces/ISimpleServiceManager.sol
+++ b/src/interfaces/ISimpleServiceManager.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.12;
+
+import {Task} from "./IPredicateManager.sol";
+
+/**
+ * @title Minimal interface for a ServiceManager-type contract that forms the single point for an AVS to push updates to EigenLayer
+ * @author Predicate Labs, Inc
+ */
+interface ISimpleServiceManager {
+    /**
+     * @notice Sets a policy ID for the sender, defining execution rules or parameters for tasks
+     * @param policyID string pointing to the policy details
+     * @dev Only callable by client contracts or EOAs to associate a policy with their address
+     * @dev Emits a SetPolicy event upon successful association
+     */
+    function setPolicy(
+        string memory policyID
+    ) external;
+
+    /**
+     * @notice Verifies if a task is authorized by the required number of operators
+     * @param _task Parameters of the task including sender, target, function signature, arguments, quorum count, and expiry block
+     * @param signerAddresses Array of addresses of the operators who signed the task
+     * @param signatures Array of signatures from the operators authorizing the task
+     * @return isVerified Boolean indicating if the task has been verified by the required number of operators
+     * @dev This function checks the signatures against the hash of the task parameters to ensure task authenticity and authorization
+     */
+    function validateSignatures(
+        Task memory _task,
+        address[] memory signerAddresses,
+        bytes[] memory signatures
+    ) external returns (bool isVerified);
+}

--- a/src/mixins/PredicateClient.sol
+++ b/src/mixins/PredicateClient.sol
@@ -27,7 +27,7 @@ abstract contract PredicateClient is IPredicateClient {
     function _initPredicateClient(address _serviceManagerAddress, string memory _policyID) internal {
         PredicateClientStorage storage $ = _getPredicateClientStorage();
         $.serviceManager = IPredicateManager(_serviceManagerAddress);
-        $.policyID = _policyID;
+        _setPolicy(_policyID);
     }
 
     function _setPolicy(
@@ -35,6 +35,7 @@ abstract contract PredicateClient is IPredicateClient {
     ) internal {
         PredicateClientStorage storage $ = _getPredicateClientStorage();
         $.policyID = _policyID;
+        $.serviceManager.setPolicy(_policyID);
     }
 
     function getPolicy() external view override returns (string memory) {

--- a/test/Client.t.sol
+++ b/test/Client.t.sol
@@ -13,8 +13,8 @@ contract MockClientTest is ServiceManagerSetup {
 
     function testOwnerCanSetPolicy() public {
         vm.prank(owner);
-        client.setPolicy("testpolicy99");
-        assertEq(client.getPolicy(), "testpolicy99");
+        client.setPolicy(policyID);
+        assertEq(client.getPolicy(), policyID);
     }
 
     function testRandomAccountCannotSetPolicy() public {

--- a/test/SimpleServiceManager.t.sol
+++ b/test/SimpleServiceManager.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {Test, console} from "forge-std/Test.sol";
+
+import {ISignatureUtils} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
+
+import {ServiceManager} from "../src/ServiceManager.sol";
+import {Task} from "../src/interfaces/IPredicateManager.sol";
+import {MockClient} from "./helpers/mocks/MockClient.sol";
+import {MockProxy} from "./helpers/mocks/MockProxy.sol";
+import {MockProxyAdmin} from "./helpers/mocks/MockProxyAdmin.sol";
+import {MockStakeRegistry} from "./helpers/mocks/MockStakeRegistry.sol";
+import {MockDelegationManager} from "./helpers/mocks/MockDelegationManager.sol";
+import {IPauserRegistry} from "./helpers/eigenlayer/interfaces/IPauserRegistry.sol";
+import {IDelegationManager} from "./helpers/eigenlayer/interfaces/IDelegationManager.sol";
+import {MockStrategyManager} from "./helpers/mocks/MockStrategyManager.sol";
+import {MockEigenPodManager} from "./helpers/mocks/MockEigenPodManager.sol";
+import {SimpleServiceManagerSetup} from "./helpers/utility/SimpleServiceManagerSetup.sol";
+
+import "./helpers/utility/TestUtils.sol";
+import "./helpers/utility/ServiceManagerSetup.sol";
+import "./helpers/utility/OperatorTestPrep.sol";
+
+contract SimpleServiceManager is SimpleServiceManagerSetup {
+    string constant TASK_ID = "test-task-001";
+    uint32 constant QUORUM_THRESHOLD = 1;
+
+    function testValidateSignaturesSuccessful() public {
+        Task memory task = Task({
+            taskId: TASK_ID,
+            msgSender: address(this),
+            target: address(client),
+            value: 0,
+            encodedSigAndArgs: "",
+            policyID: policyID,
+            quorumThresholdCount: QUORUM_THRESHOLD,
+            expireByBlockNumber: block.number + 100
+        });
+
+        bytes32 taskHash = new ServiceManager().hashTaskWithExpiry(task);
+
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(operatorOneAliasPk, taskHash);
+        bytes memory signature1 = abi.encodePacked(r1, s1, v1);
+
+        address[] memory signerAddresses = new address[](1);
+        bytes[] memory signatures = new bytes[](1);
+        signerAddresses[0] = operatorOneAlias;
+        signatures[0] = signature1;
+
+        vm.prank(address(client));
+        bool isVerified = simpleServiceManager.validateSignatures(task, signerAddresses, signatures);
+        assertTrue(isVerified, "Signature validation should pass");
+    }
+
+    function testSyncPolicies() public {
+        string[] memory policyIDs = new string[](2);
+        uint32[] memory thresholds = new uint32[](2);
+
+        policyIDs[0] = "policy-001";
+        policyIDs[1] = "policy-002";
+        thresholds[0] = 2;
+        thresholds[1] = 3;
+
+        vm.prank(owner);
+        simpleServiceManager.syncPolicies(policyIDs, thresholds);
+
+        // Verify thresholds were set correctly
+        assertEq(simpleServiceManager.policyIDToThreshold(policyIDs[0]), 2);
+        assertEq(simpleServiceManager.policyIDToThreshold(policyIDs[1]), 3);
+
+        // Verify policy IDs were added to deployedPolicyIDs array
+        // note: a policy was already deployed in the simple service manager setup
+        assertEq(simpleServiceManager.deployedPolicyIDs(1), policyIDs[0]);
+        assertEq(simpleServiceManager.deployedPolicyIDs(2), policyIDs[1]);
+    }
+
+    function testSyncOperators() public {
+        address[] memory registrationKeys = new address[](2);
+        address[] memory signingKeys = new address[](2);
+        registrationKeys[0] = operatorOne;
+        registrationKeys[1] = operatorTwo;
+        signingKeys[0] = operatorOneAlias;
+        signingKeys[1] = operatorTwoAlias;
+
+        // Expect two operators to be registered
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRegistered(operatorOne);
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRegistered(operatorTwo);
+
+        vm.prank(owner);
+        simpleServiceManager.syncOperators(registrationKeys, signingKeys);
+
+        // Verify signing key to operator mappings
+        assertEq(simpleServiceManager.signingKeyToOperatorAddress(signingKeys[0]), registrationKeys[0]);
+        assertEq(simpleServiceManager.signingKeyToOperatorAddress(signingKeys[1]), registrationKeys[1]);
+
+        //////////////// Test removing an operator and adding a new one ////////////////
+        (address operatorThree, uint256 operatorThreePk) = makeAddrAndKey("operatorFour");
+        (address operatorThreeAlias, uint256 operatorThreeAliasPk) = makeAddrAndKey("operatorFourAlias");
+
+        address[] memory newRegistrationKeys = new address[](2);
+        address[] memory newSigningKeys = new address[](2);
+
+        newRegistrationKeys[0] = operatorOne;
+        newRegistrationKeys[1] = operatorThree;
+
+        newSigningKeys[0] = operatorOneAlias;
+        newSigningKeys[1] = operatorThreeAlias;
+
+        // Expect removed operators events
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRemoved(operatorOne);
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRemoved(operatorTwo);
+
+        // Expect registered operators events
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRegistered(operatorOne);
+        vm.expectEmit(true, true, true, true);
+        emit OperatorRegistered(operatorThree);
+
+        // Sync operators again
+        vm.prank(owner);
+        simpleServiceManager.syncOperators(newRegistrationKeys, newSigningKeys);
+
+        // Verify correct signing key mappings
+        assertEq(simpleServiceManager.signingKeyToOperatorAddress(newSigningKeys[0]), newRegistrationKeys[0]);
+        assertEq(simpleServiceManager.signingKeyToOperatorAddress(newSigningKeys[1]), newRegistrationKeys[1]);
+
+        // operatorTwo should know longer be registered
+        assertEq(simpleServiceManager.signingKeyToOperatorAddress(signingKeys[1]), address(0));
+    }
+}

--- a/test/SimpleServiceManager.t.sol
+++ b/test/SimpleServiceManager.t.sol
@@ -83,22 +83,16 @@ contract SimpleServiceManager is SimpleServiceManagerSetup {
         signingKeys[0] = operatorOneAlias;
         signingKeys[1] = operatorTwoAlias;
 
-        // Expect two operators to be registered
-        vm.expectEmit(true, true, true, true);
-        emit OperatorRegistered(operatorOne);
-        vm.expectEmit(true, true, true, true);
-        emit OperatorRegistered(operatorTwo);
-
         vm.prank(owner);
-        simpleServiceManager.syncOperators(registrationKeys, signingKeys);
+        simpleServiceManager.syncOperators(registrationKeys, signingKeys, new address[](0));
 
         // Verify signing key to operator mappings
         assertEq(simpleServiceManager.signingKeyToOperatorAddress(signingKeys[0]), registrationKeys[0]);
         assertEq(simpleServiceManager.signingKeyToOperatorAddress(signingKeys[1]), registrationKeys[1]);
 
         //////////////// Test removing an operator and adding a new one ////////////////
-        (address operatorThree, uint256 operatorThreePk) = makeAddrAndKey("operatorFour");
-        (address operatorThreeAlias, uint256 operatorThreeAliasPk) = makeAddrAndKey("operatorFourAlias");
+        (address operatorThree, uint256 operatorThreePk) = makeAddrAndKey("operatorThree");
+        (address operatorThreeAlias, uint256 operatorThreeAliasPk) = makeAddrAndKey("operatorThreeAlias");
 
         address[] memory newRegistrationKeys = new address[](2);
         address[] memory newSigningKeys = new address[](2);
@@ -123,7 +117,7 @@ contract SimpleServiceManager is SimpleServiceManagerSetup {
 
         // Sync operators again
         vm.prank(owner);
-        simpleServiceManager.syncOperators(newRegistrationKeys, newSigningKeys);
+        simpleServiceManager.syncOperators(newRegistrationKeys, newSigningKeys, registrationKeys);
 
         // Verify correct signing key mappings
         assertEq(simpleServiceManager.signingKeyToOperatorAddress(newSigningKeys[0]), newRegistrationKeys[0]);

--- a/test/helpers/utility/ServiceManagerSetup.sol
+++ b/test/helpers/utility/ServiceManagerSetup.sol
@@ -35,14 +35,18 @@ contract ServiceManagerSetup is TestStorage {
 
         vm.startPrank(address(this));
         serviceManager.deployPolicy(
-            "testPolicy",
+            policyID,
             '{"version":"1.0.0","name":"testPolicy","rules":[{"id":"membership-check-sg-1","effect":"deny", "predicate_id":"membership", "predicate_params":{"social_graph_id": "sg_1"}}],"consensus": {"broadcast": "all", "threshold": "1"}}',
             1
         );
         vm.stopPrank();
 
-        client = new MockClient(owner, address(serviceManager), "testPolicy");
+        client = new MockClient(owner, address(serviceManager), policyID);
         ownableClientInterface = Ownable(address(client));
+
+        console.log("client address: %s", address(client));
+        console.log("Policy for client: %s", serviceManager.clientToPolicyID(address(client)));
+
         (operatorOne, operatorOnePk) = makeAddrAndKey("operatorOne");
         (operatorOneAlias, operatorOneAliasPk) = makeAddrAndKey("operatorOneAlias");
         (operatorTwo, operatorTwoPk) = makeAddrAndKey("operatorTwo");

--- a/test/helpers/utility/ServiceManagerSetup.sol
+++ b/test/helpers/utility/ServiceManagerSetup.sol
@@ -44,9 +44,6 @@ contract ServiceManagerSetup is TestStorage {
         client = new MockClient(owner, address(serviceManager), policyID);
         ownableClientInterface = Ownable(address(client));
 
-        console.log("client address: %s", address(client));
-        console.log("Policy for client: %s", serviceManager.clientToPolicyID(address(client)));
-
         (operatorOne, operatorOnePk) = makeAddrAndKey("operatorOne");
         (operatorOneAlias, operatorOneAliasPk) = makeAddrAndKey("operatorOneAlias");
         (operatorTwo, operatorTwoPk) = makeAddrAndKey("operatorTwo");

--- a/test/helpers/utility/SimpleServiceManagerSetup.sol
+++ b/test/helpers/utility/SimpleServiceManagerSetup.sol
@@ -41,7 +41,7 @@ contract SimpleServiceManagerSetup is TestStorage {
         signingKeys[0] = operatorOneAlias;
         signingKeys[1] = operatorTwoAlias;
 
-        simpleServiceManager.syncOperators(registrationKeys, signingKeys);
+        simpleServiceManager.syncOperators(registrationKeys, signingKeys, new address[](0));
         vm.stopPrank();
     }
 }

--- a/test/helpers/utility/SimpleServiceManagerSetup.sol
+++ b/test/helpers/utility/SimpleServiceManagerSetup.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import {Test, console} from "forge-std/Test.sol";
+import "./TestStorage.sol";
+import {SimpleServiceManager} from "../../../src/SimpleServiceManager.sol";
+
+contract SimpleServiceManagerSetup is TestStorage {
+    SimpleServiceManager public simpleServiceManagerImpl;
+    SimpleServiceManager public simpleServiceManager;
+    MockProxyAdmin public simpleServiceManagerAdmin;
+
+    function setUp() public virtual {
+        vm.startPrank(owner);
+        simpleServiceManagerAdmin = new MockProxyAdmin(owner);
+        simpleServiceManagerImpl = new SimpleServiceManager();
+        simpleServiceManager = SimpleServiceManager(
+            address(new MockProxy(address(simpleServiceManagerImpl), address(simpleServiceManagerAdmin)))
+        );
+        simpleServiceManager.initialize(owner);
+
+        string[] memory policies = new string[](1);
+        policies[0] = policyID;
+
+        uint32[] memory thresholds = new uint32[](1);
+        thresholds[0] = 1;
+
+        simpleServiceManager.syncPolicies(policies, thresholds);
+
+        client = new MockClient(owner, address(simpleServiceManager), policyID);
+
+        (operatorOne, operatorOnePk) = makeAddrAndKey("operatorOne");
+        (operatorOneAlias, operatorOneAliasPk) = makeAddrAndKey("operatorOneAlias");
+        (operatorTwo, operatorTwoPk) = makeAddrAndKey("operatorTwo");
+        (operatorTwoAlias, operatorTwoAliasPk) = makeAddrAndKey("operatorTwoAlias");
+
+        address[] memory registrationKeys = new address[](2);
+        address[] memory signingKeys = new address[](2);
+        registrationKeys[0] = operatorOne;
+        registrationKeys[1] = operatorTwo;
+        signingKeys[0] = operatorOneAlias;
+        signingKeys[1] = operatorTwoAlias;
+
+        simpleServiceManager.syncOperators(registrationKeys, signingKeys);
+        vm.stopPrank();
+    }
+}

--- a/test/helpers/utility/TestStorage.sol
+++ b/test/helpers/utility/TestStorage.sol
@@ -53,6 +53,8 @@ contract TestStorage is Test {
     address operatorTwoAddr = makeAddr("operatorTwoAddr");
     address slasher = makeAddr("slasher");
     address pauserRegistry = makeAddr("pauserRegistry");
+
+    //TODO change "Alias" semantic to "
     address operatorOne;
     address operatorOneAlias;
     address operatorTwo;


### PR DESCRIPTION
**ServiceManager**
* Adds `overrideClientPolicyID` for multisig-controlled client policy assignment
* `validateSignatures` now uses hashTaskSafe to enforce the caller is the client
* Introduces `clientToPolicyID` to be read by offchain operators secondary to the PredicateClient (eventually primary)
* Standardizes revert messages to "Predicate." prefix
* Removes deprecated aggregator and social graph logic
* Organizes Eigenlayer config functions at the bottom

**SimpleServiceManager**
* Adds `syncPolicies` and `syncOperators` for multisig-controlled batch updates

**PredicateClient**
* `_setPolicy()` now automatically registers the policy with the configured manager

**Testing**
* Updates tests to enforce caller context, remove social graph logic, and cover new sync flows
