### PR TITLE
PRE-1719: Missing events in key setter functions

### DIFF
--- a/src/ServiceManager.sol
+++ b/src/ServiceManager.sol
@@ -61,6 +61,9 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
     event ThresholdStakeUpdated(uint256 indexed thresholdStake);
     event DelegationManagerUpdated(address indexed delegationManager);
     event StakeRegistryUpdated(address indexed stakeRegistry);
+    event OperatorSigningKeyRotated(address indexed operator, address indexed oldSigningKey, address indexed newSigningKey);
+    event PermissionedOperatorsAdded(address[] operators);
+    event PermissionedOperatorsRemoved(address[] operators);
     event TaskValidated(
         address indexed msgSender,
         address indexed target,
@@ -105,6 +108,7 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
         for (uint256 i = 0; i < _operators.length; i++) {
             permissionedOperators[_operators[i]] = true;
         }
+        emit PermissionedOperatorsAdded(_operators);
     }
 
     /**
@@ -118,6 +122,7 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
         for (uint256 i = 0; i < _operators.length; i++) {
             permissionedOperators[_operators[i]] = false;
         }
+        emit PermissionedOperatorsRemoved(_operators);
     }
 
     /**
@@ -141,6 +146,7 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
 
         delete signingKeyToOperator[_oldSigningKey];
         signingKeyToOperator[_newSigningKey] = msg.sender;
+        emit OperatorSigningKeyRotated(msg.sender, _oldSigningKey, _newSigningKey);
     }
 
     /**

--- a/src/ServiceManager.sol
+++ b/src/ServiceManager.sol
@@ -61,7 +61,9 @@ contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable 
     event ThresholdStakeUpdated(uint256 indexed thresholdStake);
     event DelegationManagerUpdated(address indexed delegationManager);
     event StakeRegistryUpdated(address indexed stakeRegistry);
-    event OperatorSigningKeyRotated(address indexed operator, address indexed oldSigningKey, address indexed newSigningKey);
+    event OperatorSigningKeyRotated(
+        address indexed operator, address indexed oldSigningKey, address indexed newSigningKey
+    );
     event PermissionedOperatorsAdded(address[] operators);
     event PermissionedOperatorsRemoved(address[] operators);
     event TaskValidated(


### PR DESCRIPTION
Updated the following functions to emit their respective events;

- `addPermissionedOperators`
- `removePermissionedOperators` 
- `rotatePredicateSigningKey` 