### PR TITLE
PRE-1720: Lack of a double-step transfer ownership pattern #10

### DIFF
--- a/src/ServiceManager.sol
+++ b/src/ServiceManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {OwnableUpgradeable} from "openzeppelin-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
 
 import {IDelegationManager} from "eigenlayer-contracts/src/contracts/interfaces/IDelegationManager.sol";
@@ -13,7 +13,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
 import {IPredicateManager, Task, SignatureWithSaltAndExpiry} from "./interfaces/IPredicateManager.sol";
 
-contract ServiceManager is IPredicateManager, Initializable, OwnableUpgradeable {
+contract ServiceManager is IPredicateManager, Initializable, Ownable2StepUpgradeable {
     error ServiceManager__Unauthorized();
     error ServiceManager__InvalidOperator();
     error ServiceManager__InvalidStrategy();

--- a/src/SimpleServiceManager.sol
+++ b/src/SimpleServiceManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import {OwnableUpgradeable} from "openzeppelin-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {Initializable} from "openzeppelin-upgradeable/proxy/utils/Initializable.sol";
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
@@ -10,7 +10,7 @@ import {IStakeRegistry} from "./interfaces/IStakeRegistry.sol";
 import {Task, SignatureWithSaltAndExpiry} from "./interfaces/IPredicateManager.sol";
 import {ISimpleServiceManager} from "./interfaces/ISimpleServiceManager.sol";
 
-contract SimpleServiceManager is ISimpleServiceManager, Initializable, OwnableUpgradeable {
+contract SimpleServiceManager is ISimpleServiceManager, Initializable, Ownable2StepUpgradeable {
     /**
      * @notice Emitted when a policy is set for a client
      */

--- a/test/Ownership.t.sol
+++ b/test/Ownership.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {MockClient} from "./helpers/mocks/MockClient.sol";
 import "./helpers/utility/ServiceManagerSetup.sol";
+import {Ownable2StepUpgradeable} from "openzeppelin-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 contract OwnershipClientTest is ServiceManagerSetup {
     function test_OwnerIsOwnerByDefault() public {
@@ -38,5 +39,15 @@ contract OwnershipServiceManagerTest is ServiceManagerSetup {
         vm.expectRevert();
         vm.prank(address(44));
         ownableSM.transferOwnership(address(33));
+    }
+
+    function test_OwnerCanTransferOwnership() public {
+        (address newOwner, ) = makeAddrAndKey("newOwner");
+        Ownable2StepUpgradeable ownableSM = Ownable2StepUpgradeable(address(serviceManager));
+        vm.prank(ownableSM.owner());
+        ownableSM.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        ownableSM.acceptOwnership();
+        assertTrue(newOwner == ownableSM.owner());
     }
 }

--- a/test/Ownership.t.sol
+++ b/test/Ownership.t.sol
@@ -42,7 +42,7 @@ contract OwnershipServiceManagerTest is ServiceManagerSetup {
     }
 
     function test_OwnerCanTransferOwnership() public {
-        (address newOwner, ) = makeAddrAndKey("newOwner");
+        (address newOwner,) = makeAddrAndKey("newOwner");
         Ownable2StepUpgradeable ownableSM = Ownable2StepUpgradeable(address(serviceManager));
         vm.prank(ownableSM.owner());
         ownableSM.transferOwnership(newOwner);

--- a/test/Ownership.t.sol
+++ b/test/Ownership.t.sol
@@ -59,26 +59,4 @@ contract OwnershipServiceManagerTest is ServiceManagerSetup {
         ownableSM.acceptOwnership();
         assertEq(ownableSM.owner(), newOwner);
     }
-
-    function test_OwnershipCancellation() public {
-        vm.startPrank(ownableSM.owner());
-        ownableSM.transferOwnership(newOwner);
-        ownableSM.transferOwnership(address(0));
-        vm.stopPrank();        
-        vm.prank(newOwner);
-        vm.expectRevert();
-        ownableSM.acceptOwnership();
-    }
-
-    function test_RenounceOwnership() public {
-        vm.startPrank(ownableSM.owner());
-        ownableSM.transferOwnership(newOwner);
-        ownableSM.renounceOwnership();
-        vm.stopPrank();
-        assertEq(ownableSM.owner(), address(0));
-        assertEq(ownableSM.pendingOwner(), address(0));
-        vm.prank(newOwner);
-        vm.expectRevert();
-        ownableSM.acceptOwnership();
-    }
 }

--- a/test/Ownership.t.sol
+++ b/test/Ownership.t.sol
@@ -59,4 +59,25 @@ contract OwnershipServiceManagerTest is ServiceManagerSetup {
         ownableSM.acceptOwnership();
         assertEq(ownableSM.owner(), newOwner);
     }
+    function test_OwnershipCancellation() public {
+        vm.startPrank(ownableSM.owner());
+        ownableSM.transferOwnership(newOwner);
+        ownableSM.transferOwnership(address(0));
+        vm.stopPrank();        
+        vm.prank(newOwner);
+        vm.expectRevert();
+        ownableSM.acceptOwnership();
+    }
+
+    function test_RenounceOwnership() public {
+        vm.startPrank(ownableSM.owner());
+        ownableSM.transferOwnership(newOwner);
+        ownableSM.renounceOwnership();
+        vm.stopPrank();
+        assertEq(ownableSM.owner(), address(0));
+        assertEq(ownableSM.pendingOwner(), address(0));
+        vm.prank(newOwner);
+        vm.expectRevert();
+        ownableSM.acceptOwnership();
+    }
 }

--- a/test/Ownership.t.sol
+++ b/test/Ownership.t.sol
@@ -59,11 +59,12 @@ contract OwnershipServiceManagerTest is ServiceManagerSetup {
         ownableSM.acceptOwnership();
         assertEq(ownableSM.owner(), newOwner);
     }
+
     function test_OwnershipCancellation() public {
         vm.startPrank(ownableSM.owner());
         ownableSM.transferOwnership(newOwner);
         ownableSM.transferOwnership(address(0));
-        vm.stopPrank();        
+        vm.stopPrank();
         vm.prank(newOwner);
         vm.expectRevert();
         ownableSM.acceptOwnership();


### PR DESCRIPTION
Adds `Ownable2StepUpgradeable` to both `serviceManager` and `simpleServiceManager`. Make sure the address of the initial caller is transferred and accepted. Tests cancellation, renouncement and basic ownership in `ownership.t.sol`.