### PR TITLE
Correct attestor to attester and verify

### DIFF
--- a/src/interfaces/IPredicateRegistry.sol
+++ b/src/interfaces/IPredicateRegistry.sol
@@ -29,8 +29,8 @@ struct Attestation {
     string uuid;
     // the timestamp by which the attestation must be executed
     uint256 expiration;
-    // the address of the attestor
-    address attestor;
+    // the address of the attester
+    address attester;
     // the signature from the attestation
     bytes signature;
 }
@@ -60,9 +60,9 @@ interface IPredicateRegistry {
     ) external view returns (string memory);
 
     /**
-     * @notice Verifies if a task is authorized by the attestor
+     * @notice Verifies if a task is authorized by the attester
      * @param _task Parameters of the task including sender, target, function signature, arguments, quorum count, and expiry block
-     * @param _attestation Attestation from the attestor
+     * @param _attestation Attestation from the attester
      * @return isVerified Boolean indicating if the task has been verified by the predicate registry
      * @dev This function checks the attestation against the hash of the task parameters to ensure task authenticity and authorization
      */

--- a/src/mixins/PredicateClient.sol
+++ b/src/mixins/PredicateClient.sol
@@ -69,7 +69,7 @@ abstract contract PredicateClient is IPredicateClient {
 
     /**
      * @notice Validates the transaction by checking the attestation.
-     * @param _attestation Attestation from the attestor authorizing the task
+     * @param _attestation Attestation from the attester authorizing the task
      * @param _encodedSigAndArgs Encoded signature and arguments for the task
      * @param _msgSender Address of the sender of the task
      * @param _msgValue Value to send with the task

--- a/test/Client.t.sol
+++ b/test/Client.t.sol
@@ -74,11 +74,11 @@ contract MetaCoinTest is PredicateRegistrySetup {
         );
 
         bytes memory signature;
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, messageHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, messageHash);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation =
-            Attestation({uuid: uuid, expiration: expireByTime, attestor: attestorOne, signature: signature});
+            Attestation({uuid: uuid, expiration: expireByTime, attester: attesterOne, signature: signature});
 
         vm.prank(clientOwner);
         client.sendCoin(testReceiver, amount, attestation);

--- a/test/PredicateRegistryAttestation.t.sol
+++ b/test/PredicateRegistryAttestation.t.sol
@@ -6,13 +6,13 @@ import {Task, Attestation} from "../src/interfaces/IPredicateRegistry.sol";
 import "./helpers/PredicateRegistrySetup.sol";
 
 contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
-    // extra attestor
-    address attestorThree;
-    uint256 attestorThreePk;
+    // extra attester
+    address attesterThree;
+    uint256 attesterThreePk;
 
     function setUp() public override {
         super.setUp();
-        (attestorThree, attestorThreePk) = makeAddrAndKey("attestorThree");
+        (attesterThree, attesterThreePk) = makeAddrAndKey("attesterThree");
     }
 
     function testValidateAttestation() public {
@@ -28,12 +28,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: signature,
             expiration: block.timestamp + 100
         });
@@ -56,12 +56,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-new",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: signature,
             expiration: block.timestamp + 100
         });
@@ -83,12 +83,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: signature,
             expiration: block.timestamp + 200
         });
@@ -110,12 +110,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: signature,
             expiration: block.timestamp + 100
         });
@@ -142,18 +142,18 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation =
-            Attestation({uuid: "uuid-1", attestor: attestorOne, signature: signature, expiration: block.timestamp});
+            Attestation({uuid: "uuid-1", attester: attesterOne, signature: signature, expiration: block.timestamp});
 
         vm.expectRevert("Predicate.validateAttestation: attestation expired");
         vm.warp(block.timestamp + 100);
         predicateRegistry.validateAttestation(task, attestation);
     }
 
-    function testCannotUseInvalidAttestor() public {
+    function testCannotUseInvalidAttester() public {
         Task memory task = Task({
             uuid: "uuid-1",
             msgSender: address(this),
@@ -166,12 +166,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorThree,
+            attester: attesterThree,
             signature: signature,
             expiration: block.timestamp + 100
         });
@@ -195,7 +195,7 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: invalidSignature,
             expiration: block.timestamp + 100
         });
@@ -204,7 +204,7 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
         predicateRegistry.validateAttestation(task, attestation);
     }
 
-    function testCannotUseDifferentAttestor() public {
+    function testCannotUseDifferentAttester() public {
         Task memory task = Task({
             uuid: "uuid-1",
             msgSender: address(this),
@@ -217,12 +217,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorTwo,
+            attester: attesterTwo,
             signature: signature,
             expiration: block.timestamp + 100
         });
@@ -231,7 +231,7 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
         predicateRegistry.validateAttestation(task, attestation);
     }
 
-    function testCannotUseDeregisteredAttestor() public {
+    function testCannotUseDeregisteredAttester() public {
         Task memory task = Task({
             uuid: "uuid-1",
             msgSender: address(this),
@@ -244,12 +244,12 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature;
         bytes32 taskDigest = predicateRegistry.hashTaskWithExpiry(task);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attestorOnePk, taskDigest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(attesterOnePk, taskDigest);
         signature = abi.encodePacked(r, s, v);
 
         Attestation memory attestation = Attestation({
             uuid: "uuid-1",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: signature,
             expiration: block.timestamp + 100
         });
@@ -258,9 +258,9 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
         bool result = predicateRegistry.validateAttestation(task, attestation);
         assertTrue(result, "First execution should succeed");
 
-        // deregister attestor
+        // deregister attester
         vm.prank(owner);
-        predicateRegistry.deregisterAttestor(attestorOne);
+        predicateRegistry.deregisterAttester(attesterOne);
 
         // create new task
         Task memory task2 = Task({
@@ -275,18 +275,18 @@ contract PredicateRegistryAttestationTest is PredicateRegistrySetup {
 
         bytes memory signature2;
         bytes32 taskDigest2 = predicateRegistry.hashTaskWithExpiry(task2);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(attestorOnePk, taskDigest2);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(attesterOnePk, taskDigest2);
         signature2 = abi.encodePacked(r2, s2, v2);
 
         Attestation memory attestation2 = Attestation({
             uuid: "uuid-2",
-            attestor: attestorOne,
+            attester: attesterOne,
             signature: signature2,
             expiration: block.timestamp + 100
         });
 
-        // cannot use deregistered attestor
-        vm.expectRevert("Predicate.validateAttestation: Attestor is not a registered attestor");
+        // cannot use deregistered attester
+        vm.expectRevert("Predicate.validateAttestation: Attester is not a registered attester");
         predicateRegistry.validateAttestation(task2, attestation2);
     }
 }

--- a/test/PredicateRegistryAttestor.t.sol
+++ b/test/PredicateRegistryAttestor.t.sol
@@ -6,70 +6,70 @@ import {PredicateRegistry} from "../src/PredicateRegistry.sol";
 import {Task, Attestation} from "../src/interfaces/IPredicateRegistry.sol";
 import "./helpers/PredicateRegistrySetup.sol";
 
-contract PredicateRegistryAttestorTest is PredicateRegistrySetup {
-    // extra attestor
-    address attestorThree;
-    uint256 attestorThreePk;
+contract PredicateRegistryAttesterTest is PredicateRegistrySetup {
+    // extra attester
+    address attesterThree;
+    uint256 attesterThreePk;
 
     function setUp() public override {
         super.setUp();
-        (attestorThree, attestorThreePk) = makeAddrAndKey("attestorThree");
+        (attesterThree, attesterThreePk) = makeAddrAndKey("attesterThree");
     }
 
-    //attestor tests
-    function testIsAttestorRegistered() public {
-        assertTrue(predicateRegistry.isAttestorRegistered(attestorOne));
-        assertTrue(predicateRegistry.isAttestorRegistered(attestorTwo));
+    //attester tests
+    function testIsAttesterRegistered() public {
+        assertTrue(predicateRegistry.isAttesterRegistered(attesterOne));
+        assertTrue(predicateRegistry.isAttesterRegistered(attesterTwo));
 
-        assertFalse(predicateRegistry.isAttestorRegistered(attestorThree));
+        assertFalse(predicateRegistry.isAttesterRegistered(attesterThree));
     }
 
-    function testRegisteredAttestors() public {
-        address[] memory registeredAttestors = predicateRegistry.getRegisteredAttestors();
-        assertEq(registeredAttestors.length, 2);
-        assertEq(registeredAttestors[0], attestorOne);
-        assertEq(registeredAttestors[1], attestorTwo);
+    function testRegisteredAttesters() public {
+        address[] memory registeredAttesters = predicateRegistry.getRegisteredAttesters();
+        assertEq(registeredAttesters.length, 2);
+        assertEq(registeredAttesters[0], attesterOne);
+        assertEq(registeredAttesters[1], attesterTwo);
     }
 
-    function testOwnerCanRegisterAttestor() public {
+    function testOwnerCanRegisterAttester() public {
         vm.prank(owner);
-        predicateRegistry.registerAttestor(attestorThree);
-        assertTrue(predicateRegistry.isAttestorRegistered(attestorThree));
-        assertEq(predicateRegistry.getRegisteredAttestors().length, 3);
-        assertEq(predicateRegistry.getRegisteredAttestors()[2], attestorThree);
+        predicateRegistry.registerAttester(attesterThree);
+        assertTrue(predicateRegistry.isAttesterRegistered(attesterThree));
+        assertEq(predicateRegistry.getRegisteredAttesters().length, 3);
+        assertEq(predicateRegistry.getRegisteredAttesters()[2], attesterThree);
     }
 
-    function testCannotRegisterAttestorThatIsAlreadyRegistered() public {
-        vm.expectRevert("Predicate.registerAttestor: attestor already registered");
+    function testCannotRegisterAttesterThatIsAlreadyRegistered() public {
+        vm.expectRevert("Predicate.registerAttester: attester already registered");
         vm.prank(owner);
-        predicateRegistry.registerAttestor(attestorOne);
+        predicateRegistry.registerAttester(attesterOne);
     }
 
-    function testOwnerCanDeregisterAttestor() public {
-        assertTrue(predicateRegistry.isAttestorRegistered(attestorOne));
+    function testOwnerCanDeregisterAttester() public {
+        assertTrue(predicateRegistry.isAttesterRegistered(attesterOne));
 
         vm.prank(owner);
-        predicateRegistry.deregisterAttestor(attestorOne);
-        assertFalse(predicateRegistry.isAttestorRegistered(attestorOne));
-        assertEq(predicateRegistry.getRegisteredAttestors().length, 1);
-        assertEq(predicateRegistry.getRegisteredAttestors()[0], attestorTwo);
+        predicateRegistry.deregisterAttester(attesterOne);
+        assertFalse(predicateRegistry.isAttesterRegistered(attesterOne));
+        assertEq(predicateRegistry.getRegisteredAttesters().length, 1);
+        assertEq(predicateRegistry.getRegisteredAttesters()[0], attesterTwo);
     }
 
-    function testCannotDeregisterAttestorThatIsNotRegistered() public {
-        vm.expectRevert("Predicate.deregisterAttestor: attestor not registered");
+    function testCannotDeregisterAttesterThatIsNotRegistered() public {
+        vm.expectRevert("Predicate.deregisterAttester: attester not registered");
         vm.prank(owner);
-        predicateRegistry.deregisterAttestor(attestorThree);
+        predicateRegistry.deregisterAttester(attesterThree);
     }
 
-    function testRandomAddrCannotRegisterAttestor() public {
+    function testRandomAddrCannotRegisterAttester() public {
         vm.prank(randomAddress);
         vm.expectRevert();
-        predicateRegistry.registerAttestor(attestorOne);
+        predicateRegistry.registerAttester(attesterOne);
     }
 
-    function testRandomAddrCannotDeregisterAttestor() public {
+    function testRandomAddrCannotDeregisterAttester() public {
         vm.prank(randomAddress);
         vm.expectRevert();
-        predicateRegistry.deregisterAttestor(attestorOne);
+        predicateRegistry.deregisterAttester(attesterOne);
     }
 }

--- a/test/helpers/PredicateRegistrySetup.sol
+++ b/test/helpers/PredicateRegistrySetup.sol
@@ -17,12 +17,12 @@ contract PredicateRegistrySetup is Test {
     // owner of the contract
     address owner = makeAddr("owner");
 
-    // attestors
-    address attestorOne;
-    uint256 attestorOnePk;
+    // attesters
+    address attesterOne;
+    uint256 attesterOnePk;
 
-    address attestorTwo;
-    uint256 attestorTwoPk;
+    address attesterTwo;
+    uint256 attesterTwoPk;
 
     // random address
     address randomAddress;
@@ -40,13 +40,13 @@ contract PredicateRegistrySetup is Test {
         predicateRegistry.initialize(owner);
         vm.stopPrank();
 
-        (attestorOne, attestorOnePk) = makeAddrAndKey("attestorOne");
-        (attestorTwo, attestorTwoPk) = makeAddrAndKey("attestorTwo");
+        (attesterOne, attesterOnePk) = makeAddrAndKey("attesterOne");
+        (attesterTwo, attesterTwoPk) = makeAddrAndKey("attesterTwo");
         (randomAddress,) = makeAddrAndKey("random");
-        // register attestors (only One and Two)
+        // register attesters (only One and Two)
         vm.startPrank(owner);
-        predicateRegistry.registerAttestor(attestorOne);
-        predicateRegistry.registerAttestor(attestorTwo);
+        predicateRegistry.registerAttester(attesterOne);
+        predicateRegistry.registerAttester(attesterTwo);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
Refactor "attestor" to "attester" across the codebase to correct a consistent misspelling.

---
<a href="https://cursor.com/background-agent?bcId=bc-24657652-04d3-45ff-944e-412c65af02c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24657652-04d3-45ff-944e-412c65af02c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

