### PR TITLE
feat(soroban): add application compliance contract (Predicate Registry)

### DIFF
--- a/soroban/Cargo.toml
+++ b/soroban/Cargo.toml
@@ -3,4 +3,5 @@ resolver = "2"
 members = [
     "test-stablecoin",
     "predicate-registry",
+    "predicate-client",
 ]

--- a/soroban/Cargo.toml
+++ b/soroban/Cargo.toml
@@ -2,4 +2,5 @@
 resolver = "2"
 members = [
     "test-stablecoin",
+    "predicate-registry",
 ]

--- a/soroban/predicate-client/Cargo.toml
+++ b/soroban/predicate-client/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
-name = "predicate-registry"
+name = "predicate-client"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [dependencies]
 soroban-sdk = "23.5.3"
+predicate-registry = { path = "../predicate-registry" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.3", features = ["testutils"] }
-ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
-rand = "0.8.5"

--- a/soroban/predicate-client/Cargo.toml
+++ b/soroban/predicate-client/Cargo.toml
@@ -12,3 +12,5 @@ predicate-registry = { path = "../predicate-registry" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.3", features = ["testutils"] }
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+rand = "0.8.5"

--- a/soroban/predicate-client/src/lib.rs
+++ b/soroban/predicate-client/src/lib.rs
@@ -3,27 +3,34 @@
 /// Re-export registry types for downstream convenience.
 pub use predicate_registry::{Attestation, RegistryError, Statement};
 
-use soroban_sdk::{vec, Address, BytesN, Env, IntoVal, String, Symbol, Val, Vec};
+use soroban_sdk::{vec, Address, Bytes, Env, IntoVal, String, Symbol, Val, Vec};
 
 /// Build a Statement and validate it against the Predicate Registry.
 ///
 /// This is the Soroban equivalent of the EVM PredicateClient._authorizeTransaction() pattern.
 ///
+/// The `uuid` and `expiration` fields are copied from the attestation into the
+/// constructed statement, mirroring the EVM pattern where these values originate
+/// from the attester's signed payload.
+///
 /// # Arguments
 /// * `e` - Soroban environment
 /// * `registry` - Address of the deployed PredicateRegistry contract
 /// * `attestation` - The signed attestation from an authorized attester
-/// * `encoded_sig_and_args` - Hash of the function call being authorized
+/// * `encoded_sig_and_args` - Encoded function call data (variable-length)
 /// * `msg_sender` - The original caller
-/// * `target` - The contract being called (typically `e.current_contract_address()`)
+/// * `msg_value` - Value sent with the transaction (token amount, equivalent to EVM msg.value)
+/// * `target` - The contract being called — callers should pass `e.current_contract_address()`
+///   so that the registry's hashStatementSafe logic can bind the attestation to this contract
 /// * `policy` - The policy ID for this contract
 /// * `network` - Network passphrase for domain separation
 pub fn authorize_transaction(
     e: &Env,
     registry: &Address,
     attestation: &Attestation,
-    encoded_sig_and_args: &BytesN<32>,
+    encoded_sig_and_args: &Bytes,
     msg_sender: &Address,
+    msg_value: i128,
     target: &Address,
     policy: &String,
     network: &String,
@@ -32,6 +39,7 @@ pub fn authorize_transaction(
         uuid: attestation.uuid.clone(),
         msg_sender: msg_sender.clone(),
         target: target.clone(),
+        msg_value,
         encoded_sig_and_args: encoded_sig_and_args.clone(),
         policy: policy.clone(),
         expiration: attestation.expiration,
@@ -42,6 +50,7 @@ pub fn authorize_transaction(
         statement.into_val(e),
         attestation.clone().into_val(e),
         network.clone().into_val(e),
+        target.clone().into_val(e),
     ];
 
     e.invoke_contract::<bool>(registry, &Symbol::new(e, "validate_attestation"), args)

--- a/soroban/predicate-client/src/lib.rs
+++ b/soroban/predicate-client/src/lib.rs
@@ -1,0 +1,48 @@
+#![no_std]
+
+/// Re-export registry types for downstream convenience.
+pub use predicate_registry::{Attestation, RegistryError, Statement};
+
+use soroban_sdk::{vec, Address, BytesN, Env, IntoVal, String, Symbol, Val, Vec};
+
+/// Build a Statement and validate it against the Predicate Registry.
+///
+/// This is the Soroban equivalent of the EVM PredicateClient._authorizeTransaction() pattern.
+///
+/// # Arguments
+/// * `e` - Soroban environment
+/// * `registry` - Address of the deployed PredicateRegistry contract
+/// * `attestation` - The signed attestation from an authorized attester
+/// * `encoded_sig_and_args` - Hash of the function call being authorized
+/// * `msg_sender` - The original caller
+/// * `target` - The contract being called (typically `e.current_contract_address()`)
+/// * `policy` - The policy ID for this contract
+/// * `network` - Network passphrase for domain separation
+pub fn authorize_transaction(
+    e: &Env,
+    registry: &Address,
+    attestation: &Attestation,
+    encoded_sig_and_args: &BytesN<32>,
+    msg_sender: &Address,
+    target: &Address,
+    policy: &String,
+    network: &String,
+) -> bool {
+    let statement = Statement {
+        uuid: attestation.uuid.clone(),
+        msg_sender: msg_sender.clone(),
+        target: target.clone(),
+        encoded_sig_and_args: encoded_sig_and_args.clone(),
+        policy: policy.clone(),
+        expiration: attestation.expiration,
+    };
+
+    let args: Vec<Val> = vec![
+        e,
+        statement.into_val(e),
+        attestation.clone().into_val(e),
+        network.clone().into_val(e),
+    ];
+
+    e.invoke_contract::<bool>(registry, &Symbol::new(e, "validate_attestation"), args)
+}

--- a/soroban/predicate-client/src/lib.rs
+++ b/soroban/predicate-client/src/lib.rs
@@ -55,3 +55,88 @@ pub fn authorize_transaction(
 
     e.invoke_contract::<bool>(registry, &Symbol::new(e, "validate_attestation"), args)
 }
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+
+    use super::*;
+    use predicate_registry::PredicateRegistryContract;
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+    fn setup_registry(e: &Env) -> (Address, Address) {
+        let owner = Address::generate(e);
+        let registry_addr = e.register(PredicateRegistryContract, (owner.clone(),));
+        (owner, registry_addr)
+    }
+
+    fn generate_ed25519_keypair(e: &Env) -> (ed25519_dalek::SigningKey, BytesN<32>) {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk_bytes = sk.verifying_key().to_bytes();
+        (sk, BytesN::from_array(e, &pk_bytes))
+    }
+
+    fn sign_hash(e: &Env, sk: &ed25519_dalek::SigningKey, hash: &BytesN<32>) -> BytesN<64> {
+        use ed25519_dalek::Signer;
+        let sig = sk.sign(&hash.to_array());
+        BytesN::from_array(e, &sig.to_bytes())
+    }
+
+    #[test]
+    fn test_authorize_transaction_end_to_end() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, registry_addr) = setup_registry(&e);
+        let network = String::from_str(&e, "Test SDF Network ; September 2015");
+
+        // Register an attester via the registry client
+        let registry_client =
+            predicate_registry::PredicateRegistryContractClient::new(&e, &registry_addr);
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        registry_client.register_attester(&owner, &pub_key);
+
+        // Simulate a downstream contract calling authorize_transaction
+        let msg_sender = Address::generate(&e);
+        let target = Address::generate(&e);
+        let policy = String::from_str(&e, "x-test-policy");
+        let encoded = Bytes::from_slice(&e, &[0xBBu8; 16]);
+        let msg_value: i128 = 1000;
+
+        // Build the statement the same way authorize_transaction will,
+        // then hash+sign it so the registry can verify.
+        let statement = Statement {
+            uuid: String::from_str(&e, "uuid-client-test"),
+            msg_sender: msg_sender.clone(),
+            target: target.clone(),
+            msg_value,
+            encoded_sig_and_args: encoded.clone(),
+            policy: policy.clone(),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = registry_client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: pub_key,
+            signature,
+        };
+
+        let result = authorize_transaction(
+            &e,
+            &registry_addr,
+            &attestation,
+            &encoded,
+            &msg_sender,
+            msg_value,
+            &target,
+            &policy,
+            &network,
+        );
+        assert!(result);
+    }
+}

--- a/soroban/predicate-registry/Cargo.toml
+++ b/soroban/predicate-registry/Cargo.toml
@@ -12,3 +12,5 @@ soroban-sdk = "23.5.3"
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.3", features = ["testutils"] }
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+rand = "0.8.5"

--- a/soroban/predicate-registry/Cargo.toml
+++ b/soroban/predicate-registry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "predicate-registry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = "23.5.3"
+
+[dev-dependencies]
+soroban-sdk = { version = "23.5.3", features = ["testutils"] }

--- a/soroban/predicate-registry/src/attesters.rs
+++ b/soroban/predicate-registry/src/attesters.rs
@@ -41,19 +41,25 @@ pub fn register(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
     // Store the vec
     e.storage().instance().set(&ATTESTERS_KEY, &attesters);
     // Mark as registered
-    e.storage()
-        .persistent()
-        .set(&att_reg_key(attester), &true);
-    e.storage().persistent().extend_ttl(&att_reg_key(attester), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+    e.storage().persistent().set(&att_reg_key(attester), &true);
+    e.storage().persistent().extend_ttl(
+        &att_reg_key(attester),
+        PERSISTENT_TTL_THRESHOLD,
+        PERSISTENT_TTL_EXTEND,
+    );
     // Store index
-    e.storage()
-        .persistent()
-        .set(&att_idx_key(attester), &index);
-    e.storage().persistent().extend_ttl(&att_idx_key(attester), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+    e.storage().persistent().set(&att_idx_key(attester), &index);
+    e.storage().persistent().extend_ttl(
+        &att_idx_key(attester),
+        PERSISTENT_TTL_THRESHOLD,
+        PERSISTENT_TTL_EXTEND,
+    );
 
     #[allow(deprecated)]
-    e.events()
-        .publish((symbol_short!("attester"), symbol_short!("reg")), attester.clone());
+    e.events().publish(
+        (symbol_short!("attester"), symbol_short!("reg")),
+        attester.clone(),
+    );
 
     Ok(())
 }
@@ -99,9 +105,7 @@ pub fn deregister(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
     // Store updated vec
     e.storage().instance().set(&ATTESTERS_KEY, &attesters);
     // Remove registration flag
-    e.storage()
-        .persistent()
-        .set(&att_reg_key(attester), &false);
+    e.storage().persistent().set(&att_reg_key(attester), &false);
     // Remove index
     e.storage().persistent().remove(&att_idx_key(attester));
 

--- a/soroban/predicate-registry/src/attesters.rs
+++ b/soroban/predicate-registry/src/attesters.rs
@@ -1,1 +1,121 @@
-// Attester management — to be implemented in a later task.
+use soroban_sdk::{symbol_short, BytesN, Env, Vec};
+
+use crate::types::RegistryError;
+
+// Storage keys
+const ATTESTERS_KEY: soroban_sdk::Symbol = symbol_short!("atts");
+
+fn att_reg_key(attester: &BytesN<32>) -> (soroban_sdk::Symbol, BytesN<32>) {
+    (symbol_short!("att_reg"), attester.clone())
+}
+
+fn att_idx_key(attester: &BytesN<32>) -> (soroban_sdk::Symbol, BytesN<32>) {
+    (symbol_short!("att_idx"), attester.clone())
+}
+
+pub fn register(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
+    // Check if already registered
+    let registered: bool = e
+        .storage()
+        .persistent()
+        .get(&att_reg_key(attester))
+        .unwrap_or(false);
+    if registered {
+        return Err(RegistryError::AttesterAlreadyRegistered);
+    }
+
+    // Get or create the attesters vec
+    let mut attesters: Vec<BytesN<32>> = e
+        .storage()
+        .instance()
+        .get(&ATTESTERS_KEY)
+        .unwrap_or(Vec::new(e));
+
+    let index = attesters.len();
+    attesters.push_back(attester.clone());
+
+    // Store the vec
+    e.storage().instance().set(&ATTESTERS_KEY, &attesters);
+    // Mark as registered
+    e.storage()
+        .persistent()
+        .set(&att_reg_key(attester), &true);
+    // Store index
+    e.storage()
+        .persistent()
+        .set(&att_idx_key(attester), &index);
+
+    e.events()
+        .publish((symbol_short!("attester"), symbol_short!("reg")), attester.clone());
+
+    Ok(())
+}
+
+pub fn deregister(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
+    // Check if registered
+    let registered: bool = e
+        .storage()
+        .persistent()
+        .get(&att_reg_key(attester))
+        .unwrap_or(false);
+    if !registered {
+        return Err(RegistryError::AttesterNotRegistered);
+    }
+
+    let mut attesters: Vec<BytesN<32>> = e
+        .storage()
+        .instance()
+        .get(&ATTESTERS_KEY)
+        .unwrap_or(Vec::new(e));
+
+    let index: u32 = e
+        .storage()
+        .persistent()
+        .get(&att_idx_key(attester))
+        .unwrap();
+
+    let last_index = attesters.len() - 1;
+
+    if index != last_index {
+        // Swap with last element
+        let last_attester = attesters.get(last_index).unwrap();
+        attesters.set(index, last_attester.clone());
+        // Update swapped element's index
+        e.storage()
+            .persistent()
+            .set(&att_idx_key(&last_attester), &index);
+    }
+
+    // Pop the last element
+    attesters.pop_back();
+
+    // Store updated vec
+    e.storage().instance().set(&ATTESTERS_KEY, &attesters);
+    // Remove registration flag
+    e.storage()
+        .persistent()
+        .set(&att_reg_key(attester), &false);
+    // Remove index
+    e.storage().persistent().remove(&att_idx_key(attester));
+
+    e.events().publish(
+        (symbol_short!("attester"), symbol_short!("dereg")),
+        attester.clone(),
+    );
+
+    Ok(())
+}
+
+pub fn is_registered(e: &Env, attester: &BytesN<32>) -> bool {
+    e.storage()
+        .persistent()
+        .get(&att_reg_key(attester))
+        .unwrap_or(false)
+}
+
+pub fn get_all(e: &Env) -> Vec<BytesN<32>> {
+    e.storage()
+        .instance()
+        .get(&ATTESTERS_KEY)
+        .unwrap_or(Vec::new(e))
+}

--- a/soroban/predicate-registry/src/attesters.rs
+++ b/soroban/predicate-registry/src/attesters.rs
@@ -2,6 +2,10 @@ use soroban_sdk::{symbol_short, BytesN, Env, Vec};
 
 use crate::types::RegistryError;
 
+/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each)
+const PERSISTENT_TTL_THRESHOLD: u32 = 518_400; // 30 days
+const PERSISTENT_TTL_EXTEND: u32 = 518_400;
+
 // Storage keys
 const ATTESTERS_KEY: soroban_sdk::Symbol = symbol_short!("atts");
 
@@ -40,11 +44,14 @@ pub fn register(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
     e.storage()
         .persistent()
         .set(&att_reg_key(attester), &true);
+    e.storage().persistent().extend_ttl(&att_reg_key(attester), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
     // Store index
     e.storage()
         .persistent()
         .set(&att_idx_key(attester), &index);
+    e.storage().persistent().extend_ttl(&att_idx_key(attester), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
 
+    #[allow(deprecated)]
     e.events()
         .publish((symbol_short!("attester"), symbol_short!("reg")), attester.clone());
 
@@ -98,6 +105,7 @@ pub fn deregister(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
     // Remove index
     e.storage().persistent().remove(&att_idx_key(attester));
 
+    #[allow(deprecated)]
     e.events().publish(
         (symbol_short!("attester"), symbol_short!("dereg")),
         attester.clone(),

--- a/soroban/predicate-registry/src/attesters.rs
+++ b/soroban/predicate-registry/src/attesters.rs
@@ -1,10 +1,13 @@
+//! Attester registration and deregistration with O(1) swap-and-pop removal.
+//!
+//! The full attester list is stored in instance storage as a `Vec`. This design
+//! assumes a small attester set (fewer than ~50 entries). For larger sets,
+//! consider a persistent-storage-based approach with a separate length counter
+//! to avoid deserializing the entire vector on every operation.
+
 use soroban_sdk::{symbol_short, BytesN, Env, Vec};
 
-use crate::types::RegistryError;
-
-/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each)
-const PERSISTENT_TTL_THRESHOLD: u32 = 518_400; // 30 days
-const PERSISTENT_TTL_EXTEND: u32 = 518_400;
+use crate::types::{RegistryError, PERSISTENT_TTL_EXTEND, PERSISTENT_TTL_THRESHOLD};
 
 // Storage keys
 const ATTESTERS_KEY: soroban_sdk::Symbol = symbol_short!("atts");
@@ -104,8 +107,8 @@ pub fn deregister(e: &Env, attester: &BytesN<32>) -> Result<(), RegistryError> {
 
     // Store updated vec
     e.storage().instance().set(&ATTESTERS_KEY, &attesters);
-    // Remove registration flag
-    e.storage().persistent().set(&att_reg_key(attester), &false);
+    // Remove registration flag (remove entirely — is_registered uses unwrap_or(false))
+    e.storage().persistent().remove(&att_reg_key(attester));
     // Remove index
     e.storage().persistent().remove(&att_idx_key(attester));
 

--- a/soroban/predicate-registry/src/attesters.rs
+++ b/soroban/predicate-registry/src/attesters.rs
@@ -1,0 +1,1 @@
+// Attester management — to be implemented in a later task.

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -28,7 +28,11 @@ impl PredicateRegistryContract {
     }
 
     /// Transfer contract ownership. Only the current owner may call this.
-    pub fn transfer_ownership(e: &Env, current_owner: Address, new_owner: Address) -> Result<(), RegistryError> {
+    pub fn transfer_ownership(
+        e: &Env,
+        current_owner: Address,
+        new_owner: Address,
+    ) -> Result<(), RegistryError> {
         require_owner(e, &current_owner)?;
         e.storage().instance().set(&OWNER, &new_owner);
         Ok(())
@@ -328,7 +332,8 @@ mod test {
             signature,
         };
 
-        let result = client.validate_attestation(&statement, &attestation, &network, &client.address);
+        let result =
+            client.validate_attestation(&statement, &attestation, &network, &client.address);
         assert!(result);
     }
 

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -27,6 +27,13 @@ impl PredicateRegistryContract {
         e.storage().instance().get(&OWNER).unwrap()
     }
 
+    /// Transfer contract ownership. Only the current owner may call this.
+    pub fn transfer_ownership(e: &Env, current_owner: Address, new_owner: Address) -> Result<(), RegistryError> {
+        require_owner(e, &current_owner)?;
+        e.storage().instance().set(&OWNER, &new_owner);
+        Ok(())
+    }
+
     /// Register a new attester. Only the contract owner may call this.
     pub fn register_attester(
         e: &Env,
@@ -68,18 +75,25 @@ impl PredicateRegistryContract {
     }
 
     /// Compute SHA-256 hash of a statement for attester signing.
+    /// This is the "hashStatementWithExpiry" equivalent — attesters sign this hash.
     pub fn hash_statement(e: &Env, statement: Statement, network: String) -> BytesN<32> {
         validation::compute_hash(e, &statement, &network)
     }
 
     /// Validate an attestation against a statement.
+    ///
+    /// The `caller` parameter implements the hashStatementSafe pattern:
+    /// it replaces `statement.target` with the actual caller address before
+    /// verifying the signature, preventing cross-contract replay attacks.
+    /// In Soroban, the calling contract should pass `e.current_contract_address()`.
     pub fn validate_attestation(
         e: &Env,
         statement: Statement,
         attestation: Attestation,
         network: String,
+        caller: Address,
     ) -> Result<bool, RegistryError> {
-        validation::validate(e, &statement, &attestation, &network)
+        validation::validate(e, &statement, &attestation, &network, &caller)
     }
 }
 
@@ -241,6 +255,31 @@ mod test {
         assert_eq!(client.get_policy_id(&caller), p2);
     }
 
+    // --- Ownership transfer tests ---
+
+    #[test]
+    fn test_transfer_ownership() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let new_owner = Address::generate(&e);
+
+        client.transfer_ownership(&owner, &new_owner);
+        assert_eq!(client.owner(), new_owner);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn test_non_owner_cannot_transfer() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+        let attacker = Address::generate(&e);
+        let new_owner = Address::generate(&e);
+
+        client.transfer_ownership(&attacker, &new_owner);
+    }
+
     // --- Validation tests ---
 
     /// Helper: create an ed25519 signing key and return (signing_key, pub_key_bytes)
@@ -273,7 +312,8 @@ mod test {
             uuid: soroban_sdk::String::from_str(&e, "uuid-happy"),
             msg_sender: Address::generate(&e),
             target: client.address.clone(),
-            encoded_sig_and_args: BytesN::from_array(&e, &[0xAAu8; 32]),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0xAAu8; 32]),
             policy: soroban_sdk::String::from_str(&e, "x-test"),
             expiration: e.ledger().timestamp() + 600,
         };
@@ -288,7 +328,7 @@ mod test {
             signature,
         };
 
-        let result = client.validate_attestation(&statement, &attestation, &network);
+        let result = client.validate_attestation(&statement, &attestation, &network, &client.address);
         assert!(result);
     }
 
@@ -310,7 +350,8 @@ mod test {
             uuid: soroban_sdk::String::from_str(&e, "uuid-expired"),
             msg_sender: Address::generate(&e),
             target: client.address.clone(),
-            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0u8; 32]),
             policy: soroban_sdk::String::from_str(&e, "x-test"),
             expiration: 0,
         };
@@ -325,7 +366,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network);
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
     }
 
     #[test]
@@ -343,7 +384,8 @@ mod test {
             uuid: soroban_sdk::String::from_str(&e, "uuid-replay"),
             msg_sender: Address::generate(&e),
             target: client.address.clone(),
-            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0u8; 32]),
             policy: soroban_sdk::String::from_str(&e, "x-test"),
             expiration: e.ledger().timestamp() + 600,
         };
@@ -359,9 +401,9 @@ mod test {
         };
 
         // First call succeeds
-        client.validate_attestation(&statement, &attestation, &network);
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
         // Second call should fail with UuidAlreadyUsed
-        client.validate_attestation(&statement, &attestation, &network);
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
     }
 
     #[test]
@@ -379,7 +421,8 @@ mod test {
             uuid: soroban_sdk::String::from_str(&e, "uuid-A"),
             msg_sender: Address::generate(&e),
             target: client.address.clone(),
-            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0u8; 32]),
             policy: soroban_sdk::String::from_str(&e, "x-test"),
             expiration: e.ledger().timestamp() + 600,
         };
@@ -394,7 +437,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network);
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
     }
 
     #[test]
@@ -412,7 +455,8 @@ mod test {
             uuid: soroban_sdk::String::from_str(&e, "uuid-exp"),
             msg_sender: Address::generate(&e),
             target: client.address.clone(),
-            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0u8; 32]),
             policy: soroban_sdk::String::from_str(&e, "x-test"),
             expiration: e.ledger().timestamp() + 600,
         };
@@ -427,7 +471,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network);
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
     }
 
     #[test]
@@ -445,7 +489,8 @@ mod test {
             uuid: soroban_sdk::String::from_str(&e, "uuid-unreg"),
             msg_sender: Address::generate(&e),
             target: client.address.clone(),
-            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0u8; 32]),
             policy: soroban_sdk::String::from_str(&e, "x-test"),
             expiration: e.ledger().timestamp() + 600,
         };
@@ -460,6 +505,46 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network);
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
+    }
+
+    #[test]
+    #[should_panic] // ed25519_verify panics on bad signature
+    fn test_validate_invalid_signature() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "testnet");
+
+        // Register attester A
+        let (sk_a, pub_key_a) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key_a);
+
+        // Also register attester B (so it's registered) but sign with A's key
+        let (_sk_b, pub_key_b) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key_b);
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-badsig"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(&e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        // Sign with key A but claim attester is key B
+        let signature = sign_hash(&e, &sk_a, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: pub_key_b, // wrong attester for this signature
+            signature,
+        };
+
+        client.validate_attestation(&statement, &attestation, &network, &client.address);
     }
 }

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -5,12 +5,15 @@ mod policy;
 mod types;
 mod validation;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 pub use types::{Attestation, RegistryError, Statement};
 
 // Storage keys
 const OWNER: Symbol = soroban_sdk::symbol_short!("owner");
+const PENDING_OWNER: Symbol = soroban_sdk::symbol_short!("pnd_own");
 
 #[contract]
 pub struct PredicateRegistryContract;
@@ -27,15 +30,51 @@ impl PredicateRegistryContract {
         e.storage().instance().get(&OWNER).unwrap()
     }
 
-    /// Transfer contract ownership. Only the current owner may call this.
+    /// Propose a new owner. Only the current owner may call this.
+    /// The new owner must call `accept_ownership` to finalize the transfer.
+    /// This two-step pattern mirrors EVM's Ownable2StepUpgradeable, preventing
+    /// accidental transfers to wrong addresses.
     pub fn transfer_ownership(
         e: &Env,
         current_owner: Address,
         new_owner: Address,
     ) -> Result<(), RegistryError> {
         require_owner(e, &current_owner)?;
-        e.storage().instance().set(&OWNER, &new_owner);
+        e.storage().instance().set(&PENDING_OWNER, &new_owner);
+        #[allow(deprecated)]
+        e.events().publish(
+            (symbol_short!("owner"), symbol_short!("propose")),
+            (current_owner, new_owner),
+        );
         Ok(())
+    }
+
+    /// Accept a pending ownership transfer. Only the pending owner may call this.
+    pub fn accept_ownership(e: &Env, new_owner: Address) -> Result<(), RegistryError> {
+        let pending: Address = e
+            .storage()
+            .instance()
+            .get(&PENDING_OWNER)
+            .ok_or(RegistryError::Unauthorized)?;
+        if new_owner != pending {
+            return Err(RegistryError::Unauthorized);
+        }
+        new_owner.require_auth();
+
+        let old_owner: Address = e.storage().instance().get(&OWNER).unwrap();
+        e.storage().instance().set(&OWNER, &new_owner);
+        e.storage().instance().remove(&PENDING_OWNER);
+        #[allow(deprecated)]
+        e.events().publish(
+            (symbol_short!("owner"), symbol_short!("transfer")),
+            (old_owner, new_owner),
+        );
+        Ok(())
+    }
+
+    /// Return the pending owner, if any.
+    pub fn pending_owner(e: &Env) -> Option<Address> {
+        e.storage().instance().get(&PENDING_OWNER)
     }
 
     /// Register a new attester. Only the contract owner may call this.
@@ -262,19 +301,26 @@ mod test {
     // --- Ownership transfer tests ---
 
     #[test]
-    fn test_transfer_ownership() {
+    fn test_two_step_ownership_transfer() {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
         let new_owner = Address::generate(&e);
 
+        // Step 1: propose
         client.transfer_ownership(&owner, &new_owner);
+        assert_eq!(client.owner(), owner); // still the old owner
+        assert_eq!(client.pending_owner(), Some(new_owner.clone()));
+
+        // Step 2: accept
+        client.accept_ownership(&new_owner);
         assert_eq!(client.owner(), new_owner);
+        assert_eq!(client.pending_owner(), None);
     }
 
     #[test]
     #[should_panic(expected = "Error(Contract, #1)")]
-    fn test_non_owner_cannot_transfer() {
+    fn test_non_owner_cannot_propose_transfer() {
         let e = Env::default();
         e.mock_all_auths();
         let (_owner, client) = setup(&e);
@@ -282,6 +328,19 @@ mod test {
         let new_owner = Address::generate(&e);
 
         client.transfer_ownership(&attacker, &new_owner);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn test_wrong_address_cannot_accept_ownership() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let new_owner = Address::generate(&e);
+        let attacker = Address::generate(&e);
+
+        client.transfer_ownership(&owner, &new_owner);
+        client.accept_ownership(&attacker); // wrong address
     }
 
     // --- Validation tests ---

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -5,7 +5,7 @@ mod policy;
 mod types;
 mod validation;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol, Vec};
 
 pub use types::{Attestation, RegistryError, Statement};
 
@@ -26,6 +26,36 @@ impl PredicateRegistryContract {
     pub fn owner(e: &Env) -> Address {
         e.storage().instance().get(&OWNER).unwrap()
     }
+
+    /// Register a new attester. Only the contract owner may call this.
+    pub fn register_attester(
+        e: &Env,
+        owner: Address,
+        attester: BytesN<32>,
+    ) -> Result<(), RegistryError> {
+        require_owner(e, &owner)?;
+        attesters::register(e, &attester)
+    }
+
+    /// Deregister an attester using swap-and-pop. Only the contract owner may call this.
+    pub fn deregister_attester(
+        e: &Env,
+        owner: Address,
+        attester: BytesN<32>,
+    ) -> Result<(), RegistryError> {
+        require_owner(e, &owner)?;
+        attesters::deregister(e, &attester)
+    }
+
+    /// Check whether an attester is currently registered.
+    pub fn is_attester_registered(e: &Env, attester: BytesN<32>) -> bool {
+        attesters::is_registered(e, &attester)
+    }
+
+    /// Return all registered attesters.
+    pub fn get_registered_attesters(e: &Env) -> Vec<BytesN<32>> {
+        attesters::get_all(e)
+    }
 }
 
 /// Internal helper: require that `caller` is the stored owner.
@@ -40,4 +70,111 @@ pub(crate) fn require_owner(e: &Env, caller: &Address) -> Result<(), RegistryErr
     }
     caller.require_auth();
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    extern crate std;
+
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+    use super::*;
+
+    fn setup(e: &Env) -> (Address, PredicateRegistryContractClient) {
+        let owner = Address::generate(e);
+        let address = e.register(PredicateRegistryContract, (owner.clone(),));
+        let client = PredicateRegistryContractClient::new(e, &address);
+        (owner, client)
+    }
+
+    fn generate_attester_key(e: &Env) -> BytesN<32> {
+        BytesN::from_array(e, &[1u8; 32])
+    }
+
+    fn generate_attester_key_2(e: &Env) -> BytesN<32> {
+        BytesN::from_array(e, &[2u8; 32])
+    }
+
+    #[test]
+    fn test_register_attester() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let attester = generate_attester_key(&e);
+
+        client.register_attester(&owner, &attester);
+
+        assert!(client.is_attester_registered(&attester));
+        let attesters = client.get_registered_attesters();
+        assert_eq!(attesters.len(), 1);
+        assert_eq!(attesters.get(0).unwrap(), attester);
+    }
+
+    #[test]
+    fn test_deregister_attester() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let attester = generate_attester_key(&e);
+
+        client.register_attester(&owner, &attester);
+        client.deregister_attester(&owner, &attester);
+
+        assert!(!client.is_attester_registered(&attester));
+        assert_eq!(client.get_registered_attesters().len(), 0);
+    }
+
+    #[test]
+    fn test_deregister_swap_and_pop() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let a1 = generate_attester_key(&e);
+        let a2 = generate_attester_key_2(&e);
+
+        client.register_attester(&owner, &a1);
+        client.register_attester(&owner, &a2);
+        client.deregister_attester(&owner, &a1);
+
+        assert!(!client.is_attester_registered(&a1));
+        assert!(client.is_attester_registered(&a2));
+        let attesters = client.get_registered_attesters();
+        assert_eq!(attesters.len(), 1);
+        assert_eq!(attesters.get(0).unwrap(), a2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn test_register_duplicate_attester() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let attester = generate_attester_key(&e);
+
+        client.register_attester(&owner, &attester);
+        client.register_attester(&owner, &attester);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn test_deregister_unregistered_attester() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let attester = generate_attester_key(&e);
+
+        client.deregister_attester(&owner, &attester);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn test_non_owner_cannot_register() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+        let not_owner = Address::generate(&e);
+        let attester = generate_attester_key(&e);
+
+        client.register_attester(&not_owner, &attester);
+    }
 }

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -5,7 +5,7 @@ mod policy;
 mod types;
 mod validation;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
 
 pub use types::{Attestation, RegistryError, Statement};
 
@@ -55,6 +55,16 @@ impl PredicateRegistryContract {
     /// Return all registered attesters.
     pub fn get_registered_attesters(e: &Env) -> Vec<BytesN<32>> {
         attesters::get_all(e)
+    }
+
+    /// Set the policy ID for the calling address.
+    pub fn set_policy_id(e: &Env, caller: Address, policy_id: String) {
+        policy::set(e, &caller, &policy_id);
+    }
+
+    /// Get the policy ID for a client address.
+    pub fn get_policy_id(e: &Env, client: Address) -> String {
+        policy::get(e, &client)
     }
 }
 
@@ -176,5 +186,42 @@ mod test {
         let attester = generate_attester_key(&e);
 
         client.register_attester(&not_owner, &attester);
+    }
+
+    #[test]
+    fn test_set_and_get_policy() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+        let caller = Address::generate(&e);
+        let policy = soroban_sdk::String::from_str(&e, "x-a1b2c3d4e5f6g7h8");
+
+        client.set_policy_id(&caller, &policy);
+        assert_eq!(client.get_policy_id(&caller), policy);
+    }
+
+    #[test]
+    fn test_policy_default_empty() {
+        let e = Env::default();
+        let (_owner, client) = setup(&e);
+        let caller = Address::generate(&e);
+
+        let policy = client.get_policy_id(&caller);
+        assert_eq!(policy, soroban_sdk::String::from_str(&e, ""));
+    }
+
+    #[test]
+    fn test_update_policy() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+        let caller = Address::generate(&e);
+
+        let p1 = soroban_sdk::String::from_str(&e, "policy-1");
+        let p2 = soroban_sdk::String::from_str(&e, "policy-2");
+
+        client.set_policy_id(&caller, &p1);
+        client.set_policy_id(&caller, &p2);
+        assert_eq!(client.get_policy_id(&caller), p2);
     }
 }

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -66,6 +66,21 @@ impl PredicateRegistryContract {
     pub fn get_policy_id(e: &Env, client: Address) -> String {
         policy::get(e, &client)
     }
+
+    /// Compute SHA-256 hash of a statement for attester signing.
+    pub fn hash_statement(e: &Env, statement: Statement, network: String) -> BytesN<32> {
+        validation::compute_hash(e, &statement, &network)
+    }
+
+    /// Validate an attestation against a statement.
+    pub fn validate_attestation(
+        e: &Env,
+        statement: Statement,
+        attestation: Attestation,
+        network: String,
+    ) -> Result<bool, RegistryError> {
+        validation::validate(e, &statement, &attestation, &network)
+    }
 }
 
 /// Internal helper: require that `caller` is the stored owner.
@@ -86,9 +101,10 @@ pub(crate) fn require_owner(e: &Env, caller: &Address) -> Result<(), RegistryErr
 mod test {
     extern crate std;
 
-    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, BytesN, Env};
 
     use super::*;
+    use crate::types::{Attestation, Statement};
 
     fn setup(e: &Env) -> (Address, PredicateRegistryContractClient) {
         let owner = Address::generate(e);
@@ -223,5 +239,227 @@ mod test {
         client.set_policy_id(&caller, &p1);
         client.set_policy_id(&caller, &p2);
         assert_eq!(client.get_policy_id(&caller), p2);
+    }
+
+    // --- Validation tests ---
+
+    /// Helper: create an ed25519 signing key and return (signing_key, pub_key_bytes)
+    fn generate_ed25519_keypair(e: &Env) -> (ed25519_dalek::SigningKey, BytesN<32>) {
+        use ed25519_dalek::SigningKey;
+        use rand::rngs::OsRng;
+        let sk = SigningKey::generate(&mut OsRng);
+        let pk_bytes = sk.verifying_key().to_bytes();
+        (sk, BytesN::from_array(e, &pk_bytes))
+    }
+
+    /// Helper: sign a hash (BytesN<32>) with an ed25519 signing key, returning BytesN<64>
+    fn sign_hash(e: &Env, sk: &ed25519_dalek::SigningKey, hash: &BytesN<32>) -> BytesN<64> {
+        use ed25519_dalek::Signer;
+        let sig = sk.sign(&hash.to_array());
+        BytesN::from_array(e, &sig.to_bytes())
+    }
+
+    #[test]
+    fn test_validate_attestation_happy_path() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "Test SDF Network ; September 2015");
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key);
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-happy"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            encoded_sig_and_args: BytesN::from_array(&e, &[0xAAu8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: pub_key,
+            signature,
+        };
+
+        let result = client.validate_attestation(&statement, &attestation, &network);
+        assert!(result);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn test_validate_expired_attestation() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "testnet");
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key);
+
+        // Set ledger timestamp to something > 0 so expiration=0 is expired
+        e.ledger().set_timestamp(100);
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-expired"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: 0,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: 0,
+            attester: pub_key,
+            signature,
+        };
+
+        client.validate_attestation(&statement, &attestation, &network);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_validate_uuid_replay() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "testnet");
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key);
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-replay"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: pub_key,
+            signature,
+        };
+
+        // First call succeeds
+        client.validate_attestation(&statement, &attestation, &network);
+        // Second call should fail with UuidAlreadyUsed
+        client.validate_attestation(&statement, &attestation, &network);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #6)")]
+    fn test_validate_uuid_mismatch() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "testnet");
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key);
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-A"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-B"), // mismatch
+            expiration: statement.expiration,
+            attester: pub_key,
+            signature,
+        };
+
+        client.validate_attestation(&statement, &attestation, &network);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #7)")]
+    fn test_validate_expiration_mismatch() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "testnet");
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key);
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-exp"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration + 100, // mismatch
+            attester: pub_key,
+            signature,
+        };
+
+        client.validate_attestation(&statement, &attestation, &network);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn test_validate_unregistered_attester() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+        let network = soroban_sdk::String::from_str(&e, "testnet");
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        // NOT registering attester
+
+        let statement = Statement {
+            uuid: soroban_sdk::String::from_str(&e, "uuid-unreg"),
+            msg_sender: Address::generate(&e),
+            target: client.address.clone(),
+            encoded_sig_and_args: BytesN::from_array(&e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(&e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        };
+
+        let hash = client.hash_statement(&statement, &network);
+        let signature = sign_hash(&e, &sk, &hash);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: pub_key,
+            signature,
+        };
+
+        client.validate_attestation(&statement, &attestation, &network);
     }
 }

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -1,0 +1,43 @@
+#![no_std]
+
+mod attesters;
+mod policy;
+mod types;
+mod validation;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+pub use types::{Attestation, RegistryError, Statement};
+
+// Storage keys
+const OWNER: Symbol = soroban_sdk::symbol_short!("owner");
+
+#[contract]
+pub struct PredicateRegistryContract;
+
+#[contractimpl]
+impl PredicateRegistryContract {
+    /// Initialize the registry with an owner address.
+    pub fn __constructor(e: &Env, owner: Address) {
+        e.storage().instance().set(&OWNER, &owner);
+    }
+
+    /// Return the contract owner.
+    pub fn owner(e: &Env) -> Address {
+        e.storage().instance().get(&OWNER).unwrap()
+    }
+}
+
+/// Internal helper: require that `caller` is the stored owner.
+pub(crate) fn require_owner(e: &Env, caller: &Address) -> Result<(), RegistryError> {
+    let owner: Address = e
+        .storage()
+        .instance()
+        .get(&OWNER)
+        .ok_or(RegistryError::NotInitialized)?;
+    if *caller != owner {
+        return Err(RegistryError::Unauthorized);
+    }
+    caller.require_auth();
+    Ok(())
+}

--- a/soroban/predicate-registry/src/policy.rs
+++ b/soroban/predicate-registry/src/policy.rs
@@ -1,5 +1,9 @@
 use soroban_sdk::{symbol_short, Address, Env, String};
 
+/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each)
+const PERSISTENT_TTL_THRESHOLD: u32 = 518_400; // 30 days
+const PERSISTENT_TTL_EXTEND: u32 = 518_400;
+
 const POLICY_KEY: soroban_sdk::Symbol = symbol_short!("policy");
 
 fn policy_storage_key(client: &Address) -> (soroban_sdk::Symbol, Address) {
@@ -11,6 +15,8 @@ pub fn set(e: &Env, caller: &Address, policy_id: &String) {
     e.storage()
         .persistent()
         .set(&policy_storage_key(caller), policy_id);
+    e.storage().persistent().extend_ttl(&policy_storage_key(caller), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+    #[allow(deprecated)]
     e.events()
         .publish((symbol_short!("policy"), symbol_short!("set")), (caller.clone(), policy_id.clone()));
 }

--- a/soroban/predicate-registry/src/policy.rs
+++ b/soroban/predicate-registry/src/policy.rs
@@ -1,0 +1,1 @@
+// Policy management — to be implemented in a later task.

--- a/soroban/predicate-registry/src/policy.rs
+++ b/soroban/predicate-registry/src/policy.rs
@@ -1,8 +1,6 @@
 use soroban_sdk::{symbol_short, Address, Env, String};
 
-/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each)
-const PERSISTENT_TTL_THRESHOLD: u32 = 518_400; // 30 days
-const PERSISTENT_TTL_EXTEND: u32 = 518_400;
+use crate::types::{PERSISTENT_TTL_EXTEND, PERSISTENT_TTL_THRESHOLD};
 
 const POLICY_KEY: soroban_sdk::Symbol = symbol_short!("policy");
 

--- a/soroban/predicate-registry/src/policy.rs
+++ b/soroban/predicate-registry/src/policy.rs
@@ -15,10 +15,16 @@ pub fn set(e: &Env, caller: &Address, policy_id: &String) {
     e.storage()
         .persistent()
         .set(&policy_storage_key(caller), policy_id);
-    e.storage().persistent().extend_ttl(&policy_storage_key(caller), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+    e.storage().persistent().extend_ttl(
+        &policy_storage_key(caller),
+        PERSISTENT_TTL_THRESHOLD,
+        PERSISTENT_TTL_EXTEND,
+    );
     #[allow(deprecated)]
-    e.events()
-        .publish((symbol_short!("policy"), symbol_short!("set")), (caller.clone(), policy_id.clone()));
+    e.events().publish(
+        (symbol_short!("policy"), symbol_short!("set")),
+        (caller.clone(), policy_id.clone()),
+    );
 }
 
 pub fn get(e: &Env, client: &Address) -> String {

--- a/soroban/predicate-registry/src/policy.rs
+++ b/soroban/predicate-registry/src/policy.rs
@@ -1,1 +1,23 @@
-// Policy management — to be implemented in a later task.
+use soroban_sdk::{symbol_short, Address, Env, String};
+
+const POLICY_KEY: soroban_sdk::Symbol = symbol_short!("policy");
+
+fn policy_storage_key(client: &Address) -> (soroban_sdk::Symbol, Address) {
+    (POLICY_KEY, client.clone())
+}
+
+pub fn set(e: &Env, caller: &Address, policy_id: &String) {
+    caller.require_auth();
+    e.storage()
+        .persistent()
+        .set(&policy_storage_key(caller), policy_id);
+    e.events()
+        .publish((symbol_short!("policy"), symbol_short!("set")), (caller.clone(), policy_id.clone()));
+}
+
+pub fn get(e: &Env, client: &Address) -> String {
+    e.storage()
+        .persistent()
+        .get(&policy_storage_key(client))
+        .unwrap_or(String::from_str(e, ""))
+}

--- a/soroban/predicate-registry/src/types.rs
+++ b/soroban/predicate-registry/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Address, BytesN, String};
+use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, String};
 
 /// Mirrors the EVM Statement struct.
 /// Describes a transaction to be authorized.
@@ -11,8 +11,14 @@ pub struct Statement {
     pub msg_sender: Address,
     /// Target contract address
     pub target: Address,
-    /// Encoded function call data
-    pub encoded_sig_and_args: BytesN<32>,
+    /// Value sent with the transaction (token amount).
+    /// Equivalent to EVM's msg.value — included in signed digest so
+    /// attesters can constrain transaction value.
+    pub msg_value: i128,
+    /// Encoded function signature and arguments — variable-length to match
+    /// the EVM `bytes encodedSigAndArgs` field. Callers may pass the raw
+    /// call data or a hash of it.
+    pub encoded_sig_and_args: Bytes,
     /// Policy identifier (e.g. "x-a1b2c3d4e5f6g7h8")
     pub policy: String,
     /// Deadline ledger timestamp
@@ -32,6 +38,9 @@ pub struct Attestation {
     /// Ed25519 signature (64 bytes)
     pub signature: BytesN<64>,
 }
+
+// TODO: Replace events().publish() with #[contractevent] when available in a future SDK version.
+// soroban-sdk 23.5.3 does not support #[contractevent].
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]

--- a/soroban/predicate-registry/src/types.rs
+++ b/soroban/predicate-registry/src/types.rs
@@ -1,5 +1,10 @@
 use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, String};
 
+/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each).
+/// Shared across all modules to avoid duplication.
+pub(crate) const PERSISTENT_TTL_THRESHOLD: u32 = 518_400;
+pub(crate) const PERSISTENT_TTL_EXTEND: u32 = 518_400;
+
 /// Mirrors the EVM Statement struct.
 /// Describes a transaction to be authorized.
 #[contracttype]

--- a/soroban/predicate-registry/src/types.rs
+++ b/soroban/predicate-registry/src/types.rs
@@ -1,0 +1,60 @@
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, String};
+
+/// Mirrors the EVM Statement struct.
+/// Describes a transaction to be authorized.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Statement {
+    /// Unique identifier — replay protection key
+    pub uuid: String,
+    /// Original transaction sender
+    pub msg_sender: Address,
+    /// Target contract address
+    pub target: Address,
+    /// Encoded function call data
+    pub encoded_sig_and_args: BytesN<32>,
+    /// Policy identifier (e.g. "x-a1b2c3d4e5f6g7h8")
+    pub policy: String,
+    /// Deadline ledger timestamp
+    pub expiration: u64,
+}
+
+/// Ed25519-signed authorization from an attester.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    /// Must match Statement.uuid
+    pub uuid: String,
+    /// Must match Statement.expiration
+    pub expiration: u64,
+    /// Ed25519 public key of the attester (32 bytes)
+    pub attester: BytesN<32>,
+    /// Ed25519 signature (64 bytes)
+    pub signature: BytesN<64>,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RegistryError {
+    /// Caller is not the contract owner
+    Unauthorized = 1,
+    /// Attester is already registered
+    AttesterAlreadyRegistered = 2,
+    /// Attester is not registered
+    AttesterNotRegistered = 3,
+    /// Attestation has expired
+    AttestationExpired = 4,
+    /// Statement UUID has already been spent
+    UuidAlreadyUsed = 5,
+    /// Statement/Attestation UUID mismatch
+    UuidMismatch = 6,
+    /// Statement/Attestation expiration mismatch
+    ExpirationMismatch = 7,
+    /// Ed25519 signature verification failed
+    InvalidSignature = 8,
+    /// Contract has not been initialized
+    NotInitialized = 9,
+    /// Contract has already been initialized
+    AlreadyInitialized = 10,
+}

--- a/soroban/predicate-registry/src/validation.rs
+++ b/soroban/predicate-registry/src/validation.rs
@@ -1,1 +1,81 @@
-// Validation logic — to be implemented in a later task.
+use soroban_sdk::{symbol_short, Bytes, BytesN, Env, String};
+use soroban_sdk::xdr::ToXdr;
+
+use crate::types::{Attestation, RegistryError, Statement};
+
+/// Compute SHA-256 hash of a statement + network passphrase for attester signing.
+///
+/// Uses deterministic XDR serialization of the statement and network passphrase.
+pub fn compute_hash(e: &Env, statement: &Statement, network: &String) -> BytesN<32> {
+    let mut payload = Bytes::new(e);
+
+    // Domain separator: network passphrase
+    payload.append(&network.clone().to_xdr(e));
+    // Statement fields in deterministic order
+    payload.append(&statement.clone().to_xdr(e));
+
+    e.crypto().sha256(&payload).to_bytes()
+}
+
+/// Validate an attestation against a statement.
+///
+/// Performs the following checks:
+/// 1. Attestation not expired
+/// 2. UUID not already spent (replay protection)
+/// 3. UUID matches between statement and attestation
+/// 4. Expiration matches between statement and attestation
+/// 5. Ed25519 signature verification (panics on failure)
+/// 6. Attester is registered
+/// 7. Marks UUID as spent
+/// 8. Emits validation event
+pub fn validate(
+    e: &Env,
+    statement: &Statement,
+    attestation: &Attestation,
+    network: &String,
+) -> Result<bool, RegistryError> {
+    // 1. Check expiration
+    if e.ledger().timestamp() > attestation.expiration {
+        return Err(RegistryError::AttestationExpired);
+    }
+
+    // 2. Check UUID not already spent
+    let uuid_key = (symbol_short!("uuid"), statement.uuid.clone());
+    let already_used: bool = e.storage().persistent().get(&uuid_key).unwrap_or(false);
+    if already_used {
+        return Err(RegistryError::UuidAlreadyUsed);
+    }
+
+    // 3. UUID match
+    if statement.uuid != attestation.uuid {
+        return Err(RegistryError::UuidMismatch);
+    }
+
+    // 4. Expiration match
+    if statement.expiration != attestation.expiration {
+        return Err(RegistryError::ExpirationMismatch);
+    }
+
+    // 5. Ed25519 signature verification
+    let hash = compute_hash(e, statement, network);
+    let hash_bytes: Bytes = Bytes::from_slice(e, &hash.to_array());
+    // NOTE: ed25519_verify panics on invalid signature
+    e.crypto()
+        .ed25519_verify(&attestation.attester, &hash_bytes, &attestation.signature);
+
+    // 6. Check attester is registered
+    if !crate::attesters::is_registered(e, &attestation.attester) {
+        return Err(RegistryError::AttesterNotRegistered);
+    }
+
+    // 7. Mark UUID as spent
+    e.storage().persistent().set(&uuid_key, &true);
+
+    // 8. Emit event
+    e.events().publish(
+        (symbol_short!("validate"), symbol_short!("ok")),
+        statement.uuid.clone(),
+    );
+
+    Ok(true)
+}

--- a/soroban/predicate-registry/src/validation.rs
+++ b/soroban/predicate-registry/src/validation.rs
@@ -1,0 +1,1 @@
+// Validation logic — to be implemented in a later task.

--- a/soroban/predicate-registry/src/validation.rs
+++ b/soroban/predicate-registry/src/validation.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, String};
 use soroban_sdk::xdr::ToXdr;
+use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, String};
 
 use crate::types::{Attestation, RegistryError, Statement};
 
@@ -80,7 +80,9 @@ pub fn validate(
 
     // 7. Mark UUID as spent
     e.storage().persistent().set(&uuid_key, &true);
-    e.storage().persistent().extend_ttl(&uuid_key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
+    e.storage()
+        .persistent()
+        .extend_ttl(&uuid_key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
 
     // 8. Emit event
     #[allow(deprecated)]

--- a/soroban/predicate-registry/src/validation.rs
+++ b/soroban/predicate-registry/src/validation.rs
@@ -1,7 +1,11 @@
-use soroban_sdk::{symbol_short, Bytes, BytesN, Env, String};
+use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, String};
 use soroban_sdk::xdr::ToXdr;
 
 use crate::types::{Attestation, RegistryError, Statement};
+
+/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each)
+const PERSISTENT_TTL_THRESHOLD: u32 = 518_400; // 30 days
+const PERSISTENT_TTL_EXTEND: u32 = 518_400;
 
 /// Compute SHA-256 hash of a statement + network passphrase for attester signing.
 ///
@@ -24,7 +28,7 @@ pub fn compute_hash(e: &Env, statement: &Statement, network: &String) -> BytesN<
 /// 2. UUID not already spent (replay protection)
 /// 3. UUID matches between statement and attestation
 /// 4. Expiration matches between statement and attestation
-/// 5. Ed25519 signature verification (panics on failure)
+/// 5. Ed25519 signature verification using caller-bound hash (hashStatementSafe)
 /// 6. Attester is registered
 /// 7. Marks UUID as spent
 /// 8. Emits validation event
@@ -33,6 +37,7 @@ pub fn validate(
     statement: &Statement,
     attestation: &Attestation,
     network: &String,
+    caller: &Address,
 ) -> Result<bool, RegistryError> {
     // 1. Check expiration
     if e.ledger().timestamp() > attestation.expiration {
@@ -56,8 +61,13 @@ pub fn validate(
         return Err(RegistryError::ExpirationMismatch);
     }
 
-    // 5. Ed25519 signature verification
-    let hash = compute_hash(e, statement, network);
+    // 5. Ed25519 signature verification — use caller-bound hash (hashStatementSafe)
+    // Replace statement.target with the actual caller to prevent cross-contract replay
+    let safe_statement = Statement {
+        target: caller.clone(),
+        ..statement.clone()
+    };
+    let hash = compute_hash(e, &safe_statement, network);
     let hash_bytes: Bytes = Bytes::from_slice(e, &hash.to_array());
     // NOTE: ed25519_verify panics on invalid signature
     e.crypto()
@@ -70,8 +80,10 @@ pub fn validate(
 
     // 7. Mark UUID as spent
     e.storage().persistent().set(&uuid_key, &true);
+    e.storage().persistent().extend_ttl(&uuid_key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
 
     // 8. Emit event
+    #[allow(deprecated)]
     e.events().publish(
         (symbol_short!("validate"), symbol_short!("ok")),
         statement.uuid.clone(),

--- a/soroban/predicate-registry/src/validation.rs
+++ b/soroban/predicate-registry/src/validation.rs
@@ -1,11 +1,9 @@
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, String};
 
-use crate::types::{Attestation, RegistryError, Statement};
-
-/// TTL for persistent storage entries: ~30 days in ledger close intervals (~5s each)
-const PERSISTENT_TTL_THRESHOLD: u32 = 518_400; // 30 days
-const PERSISTENT_TTL_EXTEND: u32 = 518_400;
+use crate::types::{
+    Attestation, RegistryError, Statement, PERSISTENT_TTL_EXTEND, PERSISTENT_TTL_THRESHOLD,
+};
 
 /// Compute SHA-256 hash of a statement + network passphrase for attester signing.
 ///
@@ -24,12 +22,13 @@ pub fn compute_hash(e: &Env, statement: &Statement, network: &String) -> BytesN<
 /// Validate an attestation against a statement.
 ///
 /// Performs the following checks:
+/// 0. Caller authentication (mirrors EVM's implicit msg.sender)
 /// 1. Attestation not expired
 /// 2. UUID not already spent (replay protection)
 /// 3. UUID matches between statement and attestation
 /// 4. Expiration matches between statement and attestation
-/// 5. Ed25519 signature verification using caller-bound hash (hashStatementSafe)
-/// 6. Attester is registered
+/// 5. Attester is registered (cheap lookup before expensive crypto)
+/// 6. Ed25519 signature verification using caller-bound hash (hashStatementSafe)
 /// 7. Marks UUID as spent
 /// 8. Emits validation event
 pub fn validate(
@@ -39,6 +38,11 @@ pub fn validate(
     network: &String,
     caller: &Address,
 ) -> Result<bool, RegistryError> {
+    // 0. Authenticate the caller — mirrors EVM's implicit msg.sender guarantee.
+    //    Without this, anyone could call validate_attestation with an arbitrary
+    //    caller address and burn valid UUIDs.
+    caller.require_auth();
+
     // 1. Check expiration
     if e.ledger().timestamp() > attestation.expiration {
         return Err(RegistryError::AttestationExpired);
@@ -61,7 +65,12 @@ pub fn validate(
         return Err(RegistryError::ExpirationMismatch);
     }
 
-    // 5. Ed25519 signature verification — use caller-bound hash (hashStatementSafe)
+    // 5. Check attester is registered (cheap lookup — do before expensive crypto)
+    if !crate::attesters::is_registered(e, &attestation.attester) {
+        return Err(RegistryError::AttesterNotRegistered);
+    }
+
+    // 6. Ed25519 signature verification — use caller-bound hash (hashStatementSafe)
     // Replace statement.target with the actual caller to prevent cross-contract replay
     let safe_statement = Statement {
         target: caller.clone(),
@@ -73,22 +82,21 @@ pub fn validate(
     e.crypto()
         .ed25519_verify(&attestation.attester, &hash_bytes, &attestation.signature);
 
-    // 6. Check attester is registered
-    if !crate::attesters::is_registered(e, &attestation.attester) {
-        return Err(RegistryError::AttesterNotRegistered);
-    }
-
     // 7. Mark UUID as spent
     e.storage().persistent().set(&uuid_key, &true);
     e.storage()
         .persistent()
         .extend_ttl(&uuid_key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND);
 
-    // 8. Emit event
+    // 8. Emit event (includes attester + caller for observability, mirroring EVM StatementValidated)
     #[allow(deprecated)]
     e.events().publish(
         (symbol_short!("validate"), symbol_short!("ok")),
-        statement.uuid.clone(),
+        (
+            statement.uuid.clone(),
+            attestation.attester.clone(),
+            caller.clone(),
+        ),
     );
 
     Ok(true)


### PR DESCRIPTION
## Summary

- Adds `predicate-registry` Soroban smart contract — the Stellar equivalent of the EVM `PredicateRegistry.sol` for application compliance (Track 2 of Stellar Support PRD)
- Adds `predicate-client` helper library for downstream contracts to validate attestations
- Full feature parity with EVM: attester management, policy binding, Ed25519 attestation validation with UUID replay protection

## Details

### `predicate-registry` contract
- **Owner management** — constructor-based initialization, `require_auth()` for owner-gated operations
- **Attester registration** — register/deregister Ed25519 public keys with O(1) swap-and-pop removal
- **Policy management** — self-service `set_policy_id`/`get_policy_id` per client address
- **Statement hashing** — SHA-256 over XDR-serialized statement + network passphrase (domain separation)
- **Attestation validation** — expiration check, UUID replay protection, UUID/expiration matching, Ed25519 signature verification, attester whitelist check

### `predicate-client` library
- Re-exports registry types (`Statement`, `Attestation`, `RegistryError`)
- `authorize_transaction()` helper — mirrors EVM `PredicateClient._authorizeTransaction()`

### Key Stellar/Soroban adaptations from EVM
| EVM | Soroban |
|---|---|
| ECDSA recovery | Ed25519 verify |
| `keccak256(abi.encode(...))` | `sha256(xdr(...))` |
| `block.chainid` | Network passphrase |
| `msg.sender` | Explicit address + `require_auth()` |

## Test plan

- [x] 15 unit tests for predicate-registry (attester CRUD, policy CRUD, validation happy path + 5 error cases)
- [x] All 30 workspace tests pass (`cargo test --workspace`)
- [x] WASM build succeeds — `predicate_registry.wasm` (27KB)
- [ ] Manual deployment to Stellar testnet
- [ ] Integration test with test-stablecoin contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)