### PR TITLE
feat(soroban): owner-gated upgradeability for PredicateRegistry

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -75,7 +75,7 @@ jobs:
           - name: Install Rust
             uses: dtolnay/rust-toolchain@stable
             with:
-              targets: wasm32-unknown-unknown
+              targets: wasm32-unknown-unknown, wasm32v1-none
 
           - name: Cache cargo
             uses: actions/cache@v4
@@ -90,6 +90,9 @@ jobs:
 
           - name: Build Soroban contracts
             run: cd soroban && cargo build --release --target wasm32-unknown-unknown
+
+          - name: Build predicate-registry for wasm32v1-none
+            run: cd soroban && cargo build --release --target wasm32v1-none -p predicate-registry
 
           - name: Test Soroban contracts
             run: cd soroban && cargo test

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -189,6 +189,16 @@ mod test {
     use super::*;
     use crate::types::{Attestation, Statement};
 
+    // Import the crate's own compiled WASM so the test can upload it and
+    // upgrade the registry to itself (proves the upgrade path + storage survival).
+    // Requires: stellar contract build --package predicate-registry
+    // (builds to wasm32v1-none, which the soroban host validator accepts)
+    mod registry_wasm {
+        soroban_sdk::contractimport!(
+            file = "../target/wasm32v1-none/release/predicate_registry.wasm"
+        );
+    }
+
     fn setup(e: &Env) -> (Address, PredicateRegistryContractClient) {
         let owner = Address::generate(e);
         let address = e.register(PredicateRegistryContract, (owner.clone(),));
@@ -609,6 +619,26 @@ mod test {
         let fake_hash = BytesN::from_array(&e, &[9u8; 32]);
 
         client.upgrade(&not_owner, &fake_hash);
+    }
+
+    #[test]
+    fn test_upgrade_happy_path_preserves_storage() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+
+        // Seed storage before the upgrade.
+        let attester = generate_attester_key(&e);
+        client.register_attester(&owner, &attester);
+        assert!(client.is_attester_registered(&attester));
+
+        // Upload the crate's own WASM and upgrade to it.
+        let wasm_hash = e.deployer().upload_contract_wasm(registry_wasm::WASM);
+        client.upgrade(&owner, &wasm_hash);
+
+        // Same address, same storage after the bytecode swap.
+        assert_eq!(client.owner(), owner);
+        assert!(client.is_attester_registered(&attester));
     }
 
     #[test]

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -144,6 +144,26 @@ impl PredicateRegistryContract {
     ) -> Result<bool, RegistryError> {
         validation::validate(e, &statement, &attestation, &network, &caller)
     }
+
+    /// Replace the registry's WASM bytecode in place. Only the owner may call this.
+    /// The contract address and all storage (owner, attesters, policies, spent UUIDs)
+    /// are preserved; only the executable code changes.
+    ///
+    /// `new_wasm_hash` is the SHA-256 hash of an already-uploaded contract WASM
+    /// (see `stellar contract upload`).
+    pub fn upgrade(
+        e: &Env,
+        owner: Address,
+        new_wasm_hash: BytesN<32>,
+    ) -> Result<(), RegistryError> {
+        require_owner(e, &owner)?;
+        e.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
+        #[allow(deprecated)]
+        e.events()
+            .publish((symbol_short!("upgrade"),), new_wasm_hash);
+        Ok(())
+    }
 }
 
 /// Internal helper: require that `caller` is the stored owner.
@@ -576,6 +596,19 @@ mod test {
         };
 
         client.validate_attestation(&statement, &attestation, &network, &client.address);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn test_non_owner_cannot_upgrade() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+        let not_owner = Address::generate(&e);
+        // Any 32-byte hash — the Unauthorized check fires before the WASM is touched.
+        let fake_hash = BytesN::from_array(&e, &[9u8; 32]);
+
+        client.upgrade(&not_owner, &fake_hash);
     }
 
     #[test]

--- a/soroban/scripts/upgrade-registry.sh
+++ b/soroban/scripts/upgrade-registry.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upgrade an already-deployed PredicateRegistry to freshly-built WASM.
+#
+# Prerequisites:
+#   - stellar CLI installed
+#   - The identity used must be the registry OWNER (it signs the upgrade)
+#
+# Usage:
+#   ./upgrade-registry.sh <identity> <registry_id> [network]
+#
+# Examples:
+#   ./upgrade-registry.sh deployer CAMK3PPM...
+#   ./upgrade-registry.sh deployer CAMK3PPM... mainnet
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOROBAN_DIR="$(dirname "$SCRIPT_DIR")"
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <identity> <registry_id> [network]"
+  echo ""
+  echo "  identity     Stellar CLI identity name; MUST be the registry owner"
+  echo "  registry_id  Contract ID of the deployed PredicateRegistry"
+  echo "  network      Optional network (default: testnet)"
+  exit 1
+fi
+
+IDENTITY="$1"
+REGISTRY_ID="$2"
+NETWORK="${3:-testnet}"
+OWNER_ADDRESS=$(stellar keys address "$IDENTITY")
+
+# --- Build ---
+# Use `stellar contract build` (targets wasm32v1-none). A plain
+# `cargo build --target wasm32-unknown-unknown` emits reference-types WASM that
+# the soroban host rejects at upload ("reference-types not enabled").
+
+echo "Building predicate-registry..."
+cd "$SOROBAN_DIR"
+stellar contract build --package predicate-registry
+
+WASM_PATH="$SOROBAN_DIR/target/wasm32v1-none/release/predicate_registry.wasm"
+
+if [ ! -f "$WASM_PATH" ]; then
+  echo "ERROR: WASM not found at $WASM_PATH"
+  exit 1
+fi
+
+echo "WASM size: $(wc -c < "$WASM_PATH" | tr -d ' ') bytes"
+
+# --- Upload (install) new WASM, capture its hash ---
+
+echo ""
+echo "Uploading new WASM to $NETWORK..."
+WASM_HASH=$(stellar contract upload \
+  --wasm "$WASM_PATH" \
+  --source "$IDENTITY" \
+  --network "$NETWORK")
+
+echo "New WASM hash: $WASM_HASH"
+
+# --- Invoke upgrade ---
+
+echo ""
+echo "Upgrading registry $REGISTRY_ID..."
+echo "  Owner: $OWNER_ADDRESS"
+stellar contract invoke \
+  --id "$REGISTRY_ID" \
+  --source "$IDENTITY" \
+  --network "$NETWORK" \
+  --send=yes \
+  -- \
+  upgrade \
+  --owner "$OWNER_ADDRESS" \
+  --new_wasm_hash "$WASM_HASH"
+
+echo ""
+echo "=== Registry Upgrade Complete ==="
+echo "  Network:   $NETWORK"
+echo "  Registry:  $REGISTRY_ID"
+echo "  Owner:     $OWNER_ADDRESS"
+echo "  New WASM:  $WASM_HASH"


### PR DESCRIPTION
## Summary

Makes the deployed `PredicateRegistry` Soroban contract upgradeable in place using Soroban's native upgrade mechanism (`update_current_contract_wasm`) — same contract address, storage preserved, bytecode swapped. No proxy pattern needed.

Scope is the registry only. `predicate-client` is a library linked into consumers, so there is nothing there to upgrade independently; consumer/token contracts are unchanged.

## Changes

- **`upgrade(owner, new_wasm_hash)`** on `PredicateRegistryContract`, gated by the existing `require_owner` helper (owner check + `require_auth`). Non-owner calls revert with `RegistryError::Unauthorized` (#1). Emits an `upgrade` event with the new WASM hash, following the existing event convention. No new storage keys, no version counter (the ledger already records the WASM hash).
- **Self-upgrade test** (`test_upgrade_happy_path_preserves_storage`): uploads the crate's own compiled WASM, upgrades to it, and asserts owner + a registered attester survive the swap — proving the upgrade path and storage preservation. Plus `test_non_owner_cannot_upgrade` for the auth gate.
- **`scripts/upgrade-registry.sh`**: builds → `stellar contract upload` → invokes `upgrade` on an existing registry, mirroring `deploy-registry.sh`.
- **CI**: `soroban-build` now installs the `wasm32v1-none` target and builds that artifact before `cargo test`, because the self-upgrade test `contractimport!`s it at compile time.

## Build-target note

Both the test and the ops script build with `stellar contract build` / `wasm32v1-none`, **not** `cargo build --target wasm32-unknown-unknown` — the latter emits reference-types WASM that the Soroban host rejects at upload (`reference-types not enabled`).

## Upgrade discipline

Because storage survives the bytecode swap, future registry WASM must remain compatible with the existing storage schema (owner, pending owner, attesters, policies, spent UUIDs). Adding keys is safe; changing an existing key's type/meaning requires an explicit migration.

## Testing

`cargo test` — 39 tests pass across the workspace (21 in `predicate-registry`, including both new upgrade tests). Reviewed via subagent-driven review per task plus a whole-branch review; the one Critical found (CI missing the wasm32v1-none build) is fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)