### PR TITLE
fix(soroban): bind attestation digest to the host network (FIND-001)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -97,5 +97,12 @@ jobs:
           - name: Test Soroban contracts
             run: cd soroban && cargo test
 
+          # Recomputes the attestation digest with an implementation that shares
+          # no code with the contract, and fails if the pinned constants drift
+          # from it. Without this, a failing golden test can be "fixed" by
+          # pasting in whatever digest the code now produces.
+          - name: Check attestation golden vector
+            run: node soroban/scripts/golden-vector.js --check
+
           - name: Check Rust formatting
             run: cd soroban && cargo fmt --check

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -76,6 +76,7 @@ jobs:
             uses: dtolnay/rust-toolchain@stable
             with:
               targets: wasm32-unknown-unknown, wasm32v1-none
+              components: clippy
 
           - name: Cache cargo
             uses: actions/cache@v4
@@ -103,6 +104,12 @@ jobs:
           # pasting in whatever digest the code now produces.
           - name: Check attestation golden vector
             run: node soroban/scripts/golden-vector.js --check
+
+          # --all-targets so tests are linted too, and -D warnings so lints fail
+          # the build rather than scrolling past. This denies rustc warnings as
+          # well as clippy's, which is the intent.
+          - name: Lint Soroban contracts
+            run: cd soroban && cargo clippy --workspace --all-targets -- -D warnings
 
           - name: Check Rust formatting
             run: cd soroban && cargo fmt --check

--- a/soroban/example-compliant-token/src/lib.rs
+++ b/soroban/example-compliant-token/src/lib.rs
@@ -10,7 +10,6 @@ use soroban_sdk::{
 const ADMIN: Symbol = symbol_short!("admin");
 const REGISTRY: Symbol = symbol_short!("registry");
 const POLICY: Symbol = symbol_short!("policy");
-const NETWORK: Symbol = symbol_short!("network");
 
 /// Storage key for token balances: (BALANCE, address) -> i128
 const BALANCE: Symbol = symbol_short!("balance");
@@ -39,18 +38,13 @@ impl CompliantTokenContract {
     /// * `admin` - Token admin who can mint
     /// * `registry` - Address of the deployed PredicateRegistry contract
     /// * `policy_id` - Policy identifier (e.g. "x-a1b2c3d4e5f6g7h8")
-    /// * `network` - Stellar network passphrase (e.g. "Test SDF Network ; September 2015")
-    pub fn __constructor(
-        e: &Env,
-        admin: Address,
-        registry: Address,
-        policy_id: String,
-        network: String,
-    ) {
+    ///
+    /// The network is not configured here: the registry derives it from the ledger
+    /// when it builds the attestation digest.
+    pub fn __constructor(e: &Env, admin: Address, registry: Address, policy_id: String) {
         e.storage().instance().set(&ADMIN, &admin);
         e.storage().instance().set(&REGISTRY, &registry);
         e.storage().instance().set(&POLICY, &policy_id);
-        e.storage().instance().set(&NETWORK, &network);
 
         // Register with the Predicate Registry as part of deployment, so the
         // token is usable after a single transaction.  Storing `registry` and
@@ -133,7 +127,6 @@ impl CompliantTokenContract {
         // --- Predicate compliance check ---
         let registry: Address = e.storage().instance().get(&REGISTRY).unwrap();
         let policy: String = e.storage().instance().get(&POLICY).unwrap();
-        let network: String = e.storage().instance().get(&NETWORK).unwrap();
 
         // Encode the *concrete* transfer call (selector + all arguments) so the
         // attestation binds the recipient and amount — not just the function
@@ -156,7 +149,6 @@ impl CompliantTokenContract {
             amount,
             &e.current_contract_address(),
             &policy,
-            &network,
         );
         // --- End compliance check ---
 
@@ -234,7 +226,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
 
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
         let policy_id = String::from_str(&e, "x-example-policy");
 
         let registry_owner = Address::generate(&e);
@@ -252,12 +243,7 @@ mod test {
         let admin = Address::generate(&e);
         let token_addr = e.register(
             CompliantTokenContract,
-            (
-                admin.clone(),
-                registry_addr.clone(),
-                policy_id.clone(),
-                network.clone(),
-            ),
+            (admin.clone(), registry_addr.clone(), policy_id.clone()),
         );
 
         // No register_policy() call — deployment alone must be enough.
@@ -272,7 +258,6 @@ mod test {
     fn test_constructor_does_not_require_admin_auth() {
         let e = Env::default();
 
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
         let policy_id = String::from_str(&e, "x-example-policy");
 
         let registry_owner = Address::generate(&e);
@@ -284,12 +269,7 @@ mod test {
         let third_party_admin = Address::generate(&e);
         let token_addr = e.register(
             CompliantTokenContract,
-            (
-                third_party_admin,
-                registry_addr.clone(),
-                policy_id.clone(),
-                network.clone(),
-            ),
+            (third_party_admin, registry_addr.clone(), policy_id.clone()),
         );
 
         assert_eq!(registry_client.get_policy_id(&token_addr), policy_id);
@@ -302,7 +282,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
 
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
         let policy_id = String::from_str(&e, "x-example-policy");
 
         let registry_owner = Address::generate(&e);
@@ -313,12 +292,7 @@ mod test {
         let admin = Address::generate(&e);
         let token_addr = e.register(
             CompliantTokenContract,
-            (
-                admin.clone(),
-                registry_addr.clone(),
-                policy_id.clone(),
-                network.clone(),
-            ),
+            (admin.clone(), registry_addr.clone(), policy_id.clone()),
         );
         let token = CompliantTokenContractClient::new(&e, &token_addr);
 
@@ -333,7 +307,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
 
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
         let policy_id = String::from_str(&e, "x-example-policy");
 
         // 1. Deploy the Predicate Registry
@@ -350,12 +323,7 @@ mod test {
         let admin = Address::generate(&e);
         let token_addr = e.register(
             CompliantTokenContract,
-            (
-                admin.clone(),
-                registry_addr.clone(),
-                policy_id.clone(),
-                network.clone(),
-            ),
+            (admin.clone(), registry_addr.clone(), policy_id.clone()),
         );
         let token = CompliantTokenContractClient::new(&e, &token_addr);
 
@@ -383,7 +351,7 @@ mod test {
         };
 
         // Hash and sign (this is what the Predicate API does off-chain)
-        let hash = registry_client.hash_statement(&statement, &network);
+        let hash = registry_client.hash_statement(&statement);
         let signature = sign_hash(&e, &attester_sk, &hash);
 
         let attestation = Attestation {
@@ -409,7 +377,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
 
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
         let policy_id = String::from_str(&e, "x-example-policy");
 
         let registry_owner = Address::generate(&e);
@@ -423,12 +390,7 @@ mod test {
         let admin = Address::generate(&e);
         let token_addr = e.register(
             CompliantTokenContract,
-            (
-                admin.clone(),
-                registry_addr.clone(),
-                policy_id.clone(),
-                network.clone(),
-            ),
+            (admin.clone(), registry_addr.clone(), policy_id.clone()),
         );
         let token = CompliantTokenContractClient::new(&e, &token_addr);
         token.register_policy();
@@ -450,7 +412,7 @@ mod test {
             policy: policy_id.clone(),
             expiration: e.ledger().timestamp() + 600,
         };
-        let hash = registry_client.hash_statement(&statement, &network);
+        let hash = registry_client.hash_statement(&statement);
         let signature = sign_hash(&e, &attester_sk, &hash);
         let attestation = Attestation {
             uuid: statement.uuid.clone(),
@@ -469,7 +431,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
 
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
         let policy_id = String::from_str(&e, "x-example-policy");
 
         // Deploy registry and register a real attester
@@ -484,12 +445,7 @@ mod test {
         let admin = Address::generate(&e);
         let token_addr = e.register(
             CompliantTokenContract,
-            (
-                admin.clone(),
-                registry_addr.clone(),
-                policy_id.clone(),
-                network.clone(),
-            ),
+            (admin.clone(), registry_addr.clone(), policy_id.clone()),
         );
         let token = CompliantTokenContractClient::new(&e, &token_addr);
 

--- a/soroban/predicate-client/src/lib.rs
+++ b/soroban/predicate-client/src/lib.rs
@@ -72,7 +72,10 @@ pub enum RegistryError {
 /// * `target` - The contract being called — callers should pass `e.current_contract_address()`
 ///   so that the registry's hashStatementSafe logic can bind the attestation to this contract
 /// * `policy` - The policy ID for this contract
-/// * `network` - Network passphrase for domain separation
+///
+/// Domain separation (network and registry instance) is derived by the registry
+/// from the ledger, so there is nothing for the integrator to configure or get
+/// wrong here.
 pub fn authorize_transaction(
     e: &Env,
     registry: &Address,
@@ -82,7 +85,6 @@ pub fn authorize_transaction(
     msg_value: i128,
     target: &Address,
     policy: &String,
-    network: &String,
 ) {
     let statement = Statement {
         uuid: attestation.uuid.clone(),
@@ -98,7 +100,6 @@ pub fn authorize_transaction(
         e,
         statement.into_val(e),
         attestation.clone().into_val(e),
-        network.clone().into_val(e),
         target.clone().into_val(e),
     ];
 
@@ -141,7 +142,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, registry_addr) = setup_registry(&e);
-        let network = String::from_str(&e, "Test SDF Network ; September 2015");
 
         let registry_client =
             predicate_registry::PredicateRegistryContractClient::new(&e, &registry_addr);
@@ -165,7 +165,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = registry_client.hash_statement(&statement, &network);
+        let hash = registry_client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -186,7 +186,6 @@ mod test {
             msg_value,
             &target,
             &policy,
-            &network,
         );
     }
 }

--- a/soroban/predicate-client/src/lib.rs
+++ b/soroban/predicate-client/src/lib.rs
@@ -76,6 +76,11 @@ pub enum RegistryError {
 /// Domain separation (network and registry instance) is derived by the registry
 /// from the ledger, so there is nothing for the integrator to configure or get
 /// wrong here.
+// The argument list mirrors the Statement fields on purpose. Collapsing it into a
+// params struct would make it natural to build one value and reuse it across
+// calls, and every field here has to be re-derived from the call being
+// authorized — a stale field authorizes an action other than the one executing.
+#[allow(clippy::too_many_arguments)]
 pub fn authorize_transaction(
     e: &Env,
     registry: &Address,

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -701,10 +701,7 @@ mod test {
     /// ed25519 public key for a signing seed of 32 `0x33` bytes.
     const GV_ATTESTER_PK: &str = "17cb79fb2b4120f2b1ec65e4198d6e08b28e813feb01e4a400839b85e18080ce";
     /// That key's signature over `GV_DIGEST`.
-    const GV_SIGNATURE: &str = concat!(
-        "5cd8dd1d7ce37284f17f951d7001a2f3b5927f6325d50550b87bf0396da46c72",
-        "243ed72003b1ecfa76c9cf1800e9ca1551343186231875211ec46a34810a1500",
-    );
+    const GV_SIGNATURE: &str = "5cd8dd1d7ce37284f17f951d7001a2f3b5927f6325d50550b87bf0396da46c72243ed72003b1ecfa76c9cf1800e9ca1551343186231875211ec46a34810a1500";
 
     fn unhex<const N: usize>(h: &str) -> [u8; N] {
         let bytes = h.as_bytes();

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -125,8 +125,12 @@ impl PredicateRegistryContract {
 
     /// Compute SHA-256 hash of a statement for attester signing.
     /// This is the "hashStatementWithExpiry" equivalent — attesters sign this hash.
-    pub fn hash_statement(e: &Env, statement: Statement, network: String) -> BytesN<32> {
-        validation::compute_hash(e, &statement, &network)
+    ///
+    /// The digest is bound to the host network, read from the ledger rather than
+    /// supplied by the caller, so an attestation is only valid on the chain it was
+    /// signed for.
+    pub fn hash_statement(e: &Env, statement: Statement) -> BytesN<32> {
+        validation::compute_hash(e, &statement)
     }
 
     /// Validate an attestation against a statement.
@@ -139,10 +143,9 @@ impl PredicateRegistryContract {
         e: &Env,
         statement: Statement,
         attestation: Attestation,
-        network: String,
         caller: Address,
     ) -> Result<bool, RegistryError> {
-        validation::validate(e, &statement, &attestation, &network, &caller)
+        validation::validate(e, &statement, &attestation, &caller)
     }
 
     /// Replace the registry's WASM bytecode in place. Only the owner may call this.
@@ -402,7 +405,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "Test SDF Network ; September 2015");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         client.register_attester(&owner, &pub_key);
@@ -417,7 +419,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -427,8 +429,7 @@ mod test {
             signature,
         };
 
-        let result =
-            client.validate_attestation(&statement, &attestation, &network, &client.address);
+        let result = client.validate_attestation(&statement, &attestation, &client.address);
         assert!(result);
     }
 
@@ -438,7 +439,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         client.register_attester(&owner, &pub_key);
@@ -456,7 +456,7 @@ mod test {
             expiration: 0,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -466,7 +466,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
     }
 
     #[test]
@@ -475,7 +475,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         client.register_attester(&owner, &pub_key);
@@ -490,7 +489,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -501,9 +500,9 @@ mod test {
         };
 
         // First call succeeds
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
         // Second call should fail with UuidAlreadyUsed
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
     }
 
     #[test]
@@ -512,7 +511,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         client.register_attester(&owner, &pub_key);
@@ -527,7 +525,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -537,7 +535,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
     }
 
     #[test]
@@ -546,7 +544,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         client.register_attester(&owner, &pub_key);
@@ -561,7 +558,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -571,7 +568,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
     }
 
     #[test]
@@ -580,7 +577,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (_owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         // NOT registering attester
@@ -595,7 +591,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -605,7 +601,67 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
+    }
+
+    /// Build a statement whose `target` is already the caller, so `hash_statement`
+    /// returns exactly the digest `validate_attestation` recomputes. That isolates
+    /// the domain-separation checks below from the hashStatementSafe substitution.
+    fn caller_bound_statement(e: &Env, uuid: &str, caller: &Address) -> Statement {
+        Statement {
+            uuid: soroban_sdk::String::from_str(e, uuid),
+            msg_sender: Address::generate(e),
+            target: caller.clone(),
+            msg_value: 0,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(e, &[0u8; 32]),
+            policy: soroban_sdk::String::from_str(e, "x-test"),
+            expiration: e.ledger().timestamp() + 600,
+        }
+    }
+
+    /// The network is read from the ledger rather than supplied by the caller, so
+    /// the digest changes with the chain the registry is running on. Deliberately
+    /// *not* asserted here: that two registry instances on the same network hash
+    /// differently. The registry address is not part of the preimage — see the
+    /// rationale on `validation::compute_hash`.
+    #[test]
+    fn test_digest_is_bound_to_network_id() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (_owner, client) = setup(&e);
+
+        let caller = Address::generate(&e);
+        let statement = caller_bound_statement(&e, "uuid-per-network", &caller);
+
+        let hash = client.hash_statement(&statement);
+        e.ledger().set_network_id([7u8; 32]);
+        assert_ne!(hash, client.hash_statement(&statement));
+    }
+
+    /// An attestation signed on one chain cannot be presented on another, even to
+    /// the registry deployed at the same address.
+    #[test]
+    #[should_panic(expected = "Error(Crypto, InvalidInput)")]
+    fn test_attestation_from_another_network_is_rejected() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let (owner, client) = setup(&e);
+
+        let (sk, pub_key) = generate_ed25519_keypair(&e);
+        client.register_attester(&owner, &pub_key);
+
+        let caller = Address::generate(&e);
+        let statement = caller_bound_statement(&e, "uuid-cross-network", &caller);
+
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: pub_key,
+            signature: sign_hash(&e, &sk, &client.hash_statement(&statement)),
+        };
+
+        e.ledger().set_network_id([7u8; 32]);
+        client.validate_attestation(&statement, &attestation, &caller);
     }
 
     #[test]
@@ -642,12 +698,11 @@ mod test {
     }
 
     #[test]
-    #[should_panic] // ed25519_verify panics on bad signature
+    #[should_panic(expected = "Error(Crypto, InvalidInput)")] // ed25519_verify panics on bad signature
     fn test_validate_invalid_signature() {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         // Register attester A
         let (sk_a, pub_key_a) = generate_ed25519_keypair(&e);
@@ -667,7 +722,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         // Sign with key A but claim attester is key B
         let signature = sign_hash(&e, &sk_a, &hash);
 
@@ -678,7 +733,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
     }
 
     #[test]
@@ -688,7 +743,6 @@ mod test {
         let e = Env::default();
         e.mock_all_auths();
         let (owner, client) = setup(&e);
-        let network = soroban_sdk::String::from_str(&e, "testnet");
 
         let (sk, pub_key) = generate_ed25519_keypair(&e);
         client.register_attester(&owner, &pub_key);
@@ -703,7 +757,7 @@ mod test {
             expiration: e.ledger().timestamp() + 600,
         };
 
-        let hash = client.hash_statement(&statement, &network);
+        let hash = client.hash_statement(&statement);
         let signature = sign_hash(&e, &sk, &hash);
 
         let attestation = Attestation {
@@ -713,7 +767,7 @@ mod test {
             signature,
         };
 
-        client.validate_attestation(&statement, &attestation, &network, &client.address);
+        client.validate_attestation(&statement, &attestation, &client.address);
 
         // The replay marker must be extended to the network max TTL, not a fixed
         // ~30-day window that could be archived while an attestation is still valid.

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -202,7 +202,7 @@ mod test {
         );
     }
 
-    fn setup(e: &Env) -> (Address, PredicateRegistryContractClient) {
+    fn setup(e: &Env) -> (Address, PredicateRegistryContractClient<'_>) {
         let owner = Address::generate(e);
         let address = e.register(PredicateRegistryContract, (owner.clone(),));
         let client = PredicateRegistryContractClient::new(e, &address);

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -664,6 +664,123 @@ mod test {
         client.validate_attestation(&statement, &attestation, &caller);
     }
 
+    // --- Golden vector ---
+    //
+    // Every other test here asks the contract for a digest and then signs it, so
+    // the contract is only ever checked against itself: swapping the order of the
+    // appends in `compute_hash`, or renaming a `Statement` field — `#[contracttype]`
+    // uses field names as ScMap keys — silently changes the wire format while every
+    // test still passes. A plain refactor can therefore break every attestation the
+    // API has already signed.
+    //
+    // The constants below are the fix. They come from `scripts/golden-vector.js`, a
+    // third implementation hand-rolled from the XDR spec that shares no code with
+    // this contract, so nothing but a byte-identical layout satisfies them. Pinning
+    // the same vector in the Go signer locks both sides to one value instead of each
+    // agreeing with itself.
+    //
+    // If a change here is deliberate, regenerate with that script and update both
+    // sides in the same rollout — the digest changing invalidates every attestation
+    // already issued.
+
+    /// `sha256("Test SDF Network ; September 2015")`
+    const GV_NETWORK_ID: &str = "cee0302d59844d32bdca915c8203dd44b33fbb7edc19051ea37abedf28ecd472";
+    /// Account (`G…`) strkey over a payload of 32 `0x11` bytes.
+    const GV_MSG_SENDER: &str = "GAIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCF6M";
+    /// Contract (`C…`) strkey over a payload of 32 `0x22` bytes.
+    const GV_TARGET: &str = "CARCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEIRCEVQO";
+    const GV_UUID: &str = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
+    const GV_POLICY: &str = "x-golden-vector-policy";
+    const GV_ENCODED_SIG_AND_ARGS: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+    const GV_MSG_VALUE: i128 = 1_000_000;
+    /// 2026-01-01T00:00:00Z
+    const GV_EXPIRATION: u64 = 1_767_225_600;
+
+    /// `sha256(XDR(ScVal::Bytes(GV_NETWORK_ID)) ++ XDR(statement))`
+    const GV_DIGEST: &str = "f84da64cd98e8f705c1afa37a268a7205e25bf2a71f43a6766b79292094f5cb2";
+    /// ed25519 public key for a signing seed of 32 `0x33` bytes.
+    const GV_ATTESTER_PK: &str = "17cb79fb2b4120f2b1ec65e4198d6e08b28e813feb01e4a400839b85e18080ce";
+    /// That key's signature over `GV_DIGEST`.
+    const GV_SIGNATURE: &str = concat!(
+        "5cd8dd1d7ce37284f17f951d7001a2f3b5927f6325d50550b87bf0396da46c72",
+        "243ed72003b1ecfa76c9cf1800e9ca1551343186231875211ec46a34810a1500",
+    );
+
+    fn unhex<const N: usize>(h: &str) -> [u8; N] {
+        let bytes = h.as_bytes();
+        assert_eq!(bytes.len(), N * 2, "hex literal is the wrong length");
+        let mut out = [0u8; N];
+        for (i, byte) in out.iter_mut().enumerate() {
+            let digit = |c: u8| (c as char).to_digit(16).expect("non-hex digit") as u8;
+            *byte = (digit(bytes[i * 2]) << 4) | digit(bytes[i * 2 + 1]);
+        }
+        out
+    }
+
+    fn to_hex(bytes: &[u8]) -> std::string::String {
+        let mut out = std::string::String::new();
+        for b in bytes {
+            out.push_str(&std::format!("{:02x}", b));
+        }
+        out
+    }
+
+    /// The statement the golden digest was computed over. `target` is the address
+    /// the test passes as `caller`, so `validate_attestation`'s hashStatementSafe
+    /// substitution is a no-op and it hashes exactly this.
+    fn golden_statement(e: &Env) -> Statement {
+        Statement {
+            uuid: soroban_sdk::String::from_str(e, GV_UUID),
+            msg_sender: Address::from_str(e, GV_MSG_SENDER),
+            target: Address::from_str(e, GV_TARGET),
+            msg_value: GV_MSG_VALUE,
+            encoded_sig_and_args: soroban_sdk::Bytes::from_slice(e, &GV_ENCODED_SIG_AND_ARGS),
+            policy: soroban_sdk::String::from_str(e, GV_POLICY),
+            expiration: GV_EXPIRATION,
+        }
+    }
+
+    /// The digest for a fixed statement on a fixed network must equal a value this
+    /// contract did not produce.
+    #[test]
+    fn test_golden_vector_digest() {
+        let e = Env::default();
+        e.mock_all_auths();
+        e.ledger().set_network_id(unhex::<32>(GV_NETWORK_ID));
+        let (_owner, client) = setup(&e);
+
+        let digest = client.hash_statement(&golden_statement(&e));
+
+        assert_eq!(to_hex(&digest.to_array()), GV_DIGEST);
+    }
+
+    /// The same vector through the real verification path: an externally produced
+    /// ed25519 signature over `GV_DIGEST` must satisfy `validate_attestation`. This
+    /// covers the ed25519 call too, not just the hashing.
+    #[test]
+    fn test_golden_vector_signature() {
+        let e = Env::default();
+        e.mock_all_auths();
+        e.ledger().set_network_id(unhex::<32>(GV_NETWORK_ID));
+        let (owner, client) = setup(&e);
+
+        let attester = BytesN::from_array(&e, &unhex::<32>(GV_ATTESTER_PK));
+        client.register_attester(&owner, &attester);
+
+        let statement = golden_statement(&e);
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester,
+            signature: BytesN::from_array(&e, &unhex::<64>(GV_SIGNATURE)),
+        };
+
+        // `caller` is the statement's own target, so the digest verified here is
+        // GV_DIGEST unchanged.
+        let caller = Address::from_str(&e, GV_TARGET);
+        assert!(client.validate_attestation(&statement, &attestation, &caller));
+    }
+
     #[test]
     #[should_panic(expected = "Error(Contract, #1)")]
     fn test_non_owner_cannot_upgrade() {

--- a/soroban/predicate-registry/src/validation.rs
+++ b/soroban/predicate-registry/src/validation.rs
@@ -1,16 +1,35 @@
 use soroban_sdk::xdr::ToXdr;
-use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, String};
+use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env};
 
 use crate::types::{Attestation, RegistryError, Statement};
 
-/// Compute SHA-256 hash of a statement + network passphrase for attester signing.
+/// Compute SHA-256 hash of a statement for attester signing.
 ///
-/// Uses deterministic XDR serialization of the statement and network passphrase.
-pub fn compute_hash(e: &Env, statement: &Statement, network: &String) -> BytesN<32> {
+/// The preimage is the deterministic XDR serialization of the host network ID
+/// followed by the statement. The network ID is read from the ledger rather than
+/// taken as a parameter, so a caller cannot choose the chain it is validated
+/// against — this mirrors `block.chainid` in the EVM registry's
+/// `hashStatementWithExpiry`.
+///
+/// There is no separate version tag. XDR is self-describing and length-prefixed,
+/// so layouts cannot be confused for one another: this preimage opens with
+/// `ScVal::Bytes`, where the previous one (a network passphrase) opened with
+/// `ScVal::String`, and a statement is an `ScVal::Map` that no appended field
+/// could impersonate. Changing the layout is therefore already a hard break, and
+/// a tag would only restate that.
+///
+/// The registry's own address is deliberately *not* in the preimage, matching
+/// EVM and Solana. Replay across registry instances is already constrained by
+/// the caller binding below (see `validate`): it would need one integrating
+/// contract wired to two registries running this same preimage layout. Adding
+/// the address would instead require every attester to know which registry it is
+/// signing for, and only one registry per network is deployed. If that ever
+/// changes, append `e.current_contract_address()` here.
+pub fn compute_hash(e: &Env, statement: &Statement) -> BytesN<32> {
     let mut payload = Bytes::new(e);
 
-    // Domain separator: network passphrase
-    payload.append(&network.clone().to_xdr(e));
+    // Domain separator, read from the host — not caller-supplied.
+    payload.append(&e.ledger().network_id().to_xdr(e));
     // Statement fields in deterministic order
     payload.append(&statement.clone().to_xdr(e));
 
@@ -33,7 +52,6 @@ pub fn validate(
     e: &Env,
     statement: &Statement,
     attestation: &Attestation,
-    network: &String,
     caller: &Address,
 ) -> Result<bool, RegistryError> {
     // 0. Authenticate the caller — mirrors EVM's implicit msg.sender guarantee.
@@ -79,7 +97,7 @@ pub fn validate(
         target: caller.clone(),
         ..statement.clone()
     };
-    let hash = compute_hash(e, &safe_statement, network);
+    let hash = compute_hash(e, &safe_statement);
     let hash_bytes: Bytes = Bytes::from_slice(e, &hash.to_array());
     // NOTE: ed25519_verify panics on invalid signature
     e.crypto()

--- a/soroban/scripts/deploy-compliant-token.sh
+++ b/soroban/scripts/deploy-compliant-token.sh
@@ -17,7 +17,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOROBAN_DIR="$(dirname "$SCRIPT_DIR")"
 
 NETWORK="testnet"
-NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
 if [ $# -lt 3 ]; then
   echo "Usage: $0 <identity> <registry_contract_id> <policy_id>"
@@ -55,7 +54,6 @@ echo "Deploying CompliantToken to $NETWORK..."
 echo "  Admin:     $ADMIN_ADDRESS"
 echo "  Registry:  $REGISTRY_ID"
 echo "  Policy:    $POLICY_ID"
-echo "  Network:   $NETWORK_PASSPHRASE"
 
 TOKEN_ID=$(stellar contract deploy \
   --wasm "$WASM_PATH" \
@@ -64,8 +62,7 @@ TOKEN_ID=$(stellar contract deploy \
   -- \
   --admin "$ADMIN_ADDRESS" \
   --registry "$REGISTRY_ID" \
-  --policy_id "$POLICY_ID" \
-  --network "$NETWORK_PASSPHRASE")
+  --policy_id "$POLICY_ID")
 
 echo "Token deployed: $TOKEN_ID"
 

--- a/soroban/scripts/golden-vector.js
+++ b/soroban/scripts/golden-vector.js
@@ -14,11 +14,21 @@
 // XDR spec rather than sharing code with either side. Its output is pinned as
 // constants in both, which locks them to one value instead of each to itself.
 //
-//   node soroban/scripts/golden-vector.js
+//   node soroban/scripts/golden-vector.js            # print the vector
+//   node soroban/scripts/golden-vector.js --check    # verify the pinned constants
+//
+// `--check` is what keeps this honest, and it runs in CI. A pinned constant on
+// its own only survives until someone hits a failing golden test and pastes in
+// whatever digest the code now produces — at which point the suite is green and
+// the protection is gone. Under --check that no longer works: this script's model
+// is independent, so a pasted digest disagrees with it and CI fails. Changing the
+// format then requires editing this model too, which is a visible, reviewable act
+// rather than a one-character fix.
 //
 // Consumers of the output:
-//   * soroban/predicate-registry/src/lib.rs — the GV_* constants
-//   * predicate-avs stmapiv2 — the Go golden-vector test
+//   * soroban/predicate-registry/src/lib.rs — the GV_* constants (checked here)
+//   * predicate-avs stmapiv2 — the Go golden-vector test (not reachable from
+//     this repo; keep it in step manually)
 //
 // Changing the digest invalidates every attestation already issued. If a change
 // is deliberate, regenerate here and update both sides in the same rollout.
@@ -162,17 +172,90 @@ if (!crypto.verify(null, digest, publicKey, signature)) {
   throw new Error('self-check failed: signature does not verify over the digest');
 }
 
-// --- output ------------------------------------------------------------------
+// --- the vector --------------------------------------------------------------
 
-console.log(`network passphrase   ${NETWORK_PASSPHRASE}`);
-console.log(`GV_NETWORK_ID        ${networkId.toString('hex')}`);
-console.log(`GV_MSG_SENDER        ${strkey(VERSION_BYTE_ACCOUNT, MSG_SENDER_KEY)}`);
-console.log(`GV_TARGET            ${strkey(VERSION_BYTE_CONTRACT, TARGET_KEY)}`);
-console.log(`GV_UUID              ${STATEMENT.uuid}`);
-console.log(`GV_POLICY            ${STATEMENT.policy}`);
-console.log(`GV_MSG_VALUE         ${STATEMENT.msgValue}`);
-console.log(`GV_EXPIRATION        ${STATEMENT.expiration}`);
-console.log(`preimage             ${preimage.length} bytes`);
-console.log(`GV_DIGEST            ${digest.toString('hex')}`);
-console.log(`GV_ATTESTER_PK       ${attesterPk.toString('hex')}`);
-console.log(`GV_SIGNATURE         ${signature.toString('hex')}`);
+const VECTOR = {
+  GV_NETWORK_ID: networkId.toString('hex'),
+  GV_MSG_SENDER: strkey(VERSION_BYTE_ACCOUNT, MSG_SENDER_KEY),
+  GV_TARGET: strkey(VERSION_BYTE_CONTRACT, TARGET_KEY),
+  GV_UUID: STATEMENT.uuid,
+  GV_POLICY: STATEMENT.policy,
+  GV_MSG_VALUE: STATEMENT.msgValue.toString(),
+  GV_EXPIRATION: STATEMENT.expiration.toString(),
+  GV_ENCODED_SIG_AND_ARGS: [...STATEMENT.encodedSigAndArgs].join(','),
+  GV_DIGEST: digest.toString('hex'),
+  GV_ATTESTER_PK: attesterPk.toString('hex'),
+  GV_SIGNATURE: signature.toString('hex'),
+};
+
+// --- output / check ----------------------------------------------------------
+
+const RUST_SOURCE = require('path').join(
+  __dirname,
+  '..',
+  'predicate-registry',
+  'src',
+  'lib.rs',
+);
+
+/** How each constant is written in the Rust source, so it can be read back. */
+const RUST_PATTERNS = {
+  GV_NETWORK_ID: /GV_NETWORK_ID\s*:\s*&str\s*=\s*"([0-9a-f]+)"/,
+  GV_MSG_SENDER: /GV_MSG_SENDER\s*:\s*&str\s*=\s*"([A-Z2-7]+)"/,
+  GV_TARGET: /GV_TARGET\s*:\s*&str\s*=\s*"([A-Z2-7]+)"/,
+  GV_UUID: /GV_UUID\s*:\s*&str\s*=\s*"([^"]+)"/,
+  GV_POLICY: /GV_POLICY\s*:\s*&str\s*=\s*"([^"]+)"/,
+  GV_MSG_VALUE: /GV_MSG_VALUE\s*:\s*i128\s*=\s*([0-9_]+)/,
+  GV_EXPIRATION: /GV_EXPIRATION\s*:\s*u64\s*=\s*([0-9_]+)/,
+  GV_ENCODED_SIG_AND_ARGS: /GV_ENCODED_SIG_AND_ARGS\s*:\s*\[u8;\s*\d+\]\s*=\s*\[([^\]]+)\]/,
+  GV_DIGEST: /GV_DIGEST\s*:\s*&str\s*=\s*"([0-9a-f]+)"/,
+  GV_ATTESTER_PK: /GV_ATTESTER_PK\s*:\s*&str\s*=\s*"([0-9a-f]+)"/,
+  GV_SIGNATURE: /GV_SIGNATURE\s*:\s*&str\s*=\s*"([0-9a-f]+)"/,
+};
+
+/** Rust writes numbers as 1_000_000 and byte arrays as [1, 2, 3]. */
+const normalise = (s) => s.replace(/[_\s]/g, '');
+
+function check() {
+  const source = require('fs').readFileSync(RUST_SOURCE, 'utf8');
+  const problems = [];
+
+  for (const [name, expected] of Object.entries(VECTOR)) {
+    const match = source.match(RUST_PATTERNS[name]);
+    if (!match) {
+      // Never pass silently because a constant moved or was deleted — that is
+      // exactly how a golden vector rots into a no-op.
+      problems.push(`${name}: not found in ${RUST_SOURCE}`);
+      continue;
+    }
+    const actual = normalise(match[1]);
+    if (actual !== normalise(expected)) {
+      problems.push(`${name}:\n    pinned in Rust  ${actual}\n    computed here   ${normalise(expected)}`);
+    }
+  }
+
+  if (problems.length) {
+    console.error('Golden vector mismatch — the pinned constants do not match this');
+    console.error('independent implementation:\n');
+    for (const p of problems) console.error(`  ${p}`);
+    console.error(
+      '\nIf the format change was deliberate, update the model in this script and',
+    );
+    console.error(
+      'regenerate every consumer, including the Go signer, in the same rollout.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`Golden vector OK — ${Object.keys(VECTOR).length} constants match.`);
+}
+
+if (process.argv.includes('--check')) {
+  check();
+} else {
+  console.log(`network passphrase        ${NETWORK_PASSPHRASE}`);
+  console.log(`preimage                 ${preimage.length} bytes`);
+  for (const [name, value] of Object.entries(VECTOR)) {
+    console.log(`${name.padEnd(24)} ${value}`);
+  }
+}

--- a/soroban/scripts/golden-vector.js
+++ b/soroban/scripts/golden-vector.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+//
+// Regenerates the attestation-digest golden vector.
+//
+// The digest is consumed by two independent implementations: this repo's
+// predicate-registry (`validation::compute_hash`) and the Predicate API's Go
+// signer (`stmapiv2/internal/domain/types.go`, `stellarDigestBytes`). Tests on
+// either side that ask their own code for the digest and then sign it only ever
+// check that code against itself — reordering the hash preimage, or renaming a
+// `Statement` field (`#[contracttype]` uses field names as ScMap keys), changes
+// the wire format while every such test still passes.
+//
+// So this script is a third implementation, deliberately hand-rolled from the
+// XDR spec rather than sharing code with either side. Its output is pinned as
+// constants in both, which locks them to one value instead of each to itself.
+//
+//   node soroban/scripts/golden-vector.js
+//
+// Consumers of the output:
+//   * soroban/predicate-registry/src/lib.rs — the GV_* constants
+//   * predicate-avs stmapiv2 — the Go golden-vector test
+//
+// Changing the digest invalidates every attestation already issued. If a change
+// is deliberate, regenerate here and update both sides in the same rollout.
+
+const crypto = require('crypto');
+
+// --- strkey (SEP-23) ---------------------------------------------------------
+
+const B32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const VERSION_BYTE_ACCOUNT = 6 << 3; // renders as 'G'
+const VERSION_BYTE_CONTRACT = 2 << 3; // renders as 'C'
+
+/** CRC16-XModem: polynomial 0x1021, initial value 0. */
+function crc16(buf) {
+  let crc = 0;
+  for (const byte of buf) {
+    crc ^= byte << 8;
+    for (let i = 0; i < 8; i++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc;
+}
+
+function base32(buf) {
+  let bits = '';
+  for (const byte of buf) bits += byte.toString(2).padStart(8, '0');
+  while (bits.length % 5) bits += '0';
+  let out = '';
+  for (let i = 0; i < bits.length; i += 5) {
+    out += B32_ALPHABET[parseInt(bits.slice(i, i + 5), 2)];
+  }
+  return out;
+}
+
+function strkey(versionByte, payload) {
+  const body = Buffer.concat([Buffer.from([versionByte]), payload]);
+  const checksum = crc16(body);
+  return base32(
+    Buffer.concat([body, Buffer.from([checksum & 0xff, (checksum >> 8) & 0xff])]),
+  );
+}
+
+// --- XDR ScVal ---------------------------------------------------------------
+
+const u32 = (n) => {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(n);
+  return b;
+};
+
+/** XDR pads opaque and string payloads up to a 4-byte boundary. */
+const pad4 = (b) => Buffer.concat([b, Buffer.alloc(((-b.length % 4) + 4) % 4)]);
+
+const scBytes = (b) => Buffer.concat([u32(13), u32(b.length), pad4(b)]);
+const scString = (s) => {
+  const b = Buffer.from(s, 'utf8');
+  return Buffer.concat([u32(14), u32(b.length), pad4(b)]);
+};
+const scSymbol = (s) => {
+  const b = Buffer.from(s, 'utf8');
+  return Buffer.concat([u32(15), u32(b.length), pad4(b)]);
+};
+const scU64 = (v) => {
+  const b = Buffer.alloc(8);
+  b.writeBigUInt64BE(BigInt(v));
+  return Buffer.concat([u32(5), b]);
+};
+/** ScVal::I128 carries Int128Parts { hi: int64, lo: uint64 }. */
+const scI128 = (v) => {
+  const x = BigInt(v);
+  const hi = Buffer.alloc(8);
+  const lo = Buffer.alloc(8);
+  hi.writeBigInt64BE(x >> 64n);
+  lo.writeBigUInt64BE(x & ((1n << 64n) - 1n));
+  return Buffer.concat([u32(10), hi, lo]);
+};
+// ScAddress::Account wraps AccountId -> PublicKey, a union whose own
+// discriminant (0 = ed25519) sits before the key. ScAddress::Contract wraps a
+// bare Hash and has no inner discriminant. Missing those 4 bytes is the easiest
+// way to get this encoding subtly wrong.
+const scAccount = (key) => Buffer.concat([u32(18), u32(0), u32(0), key]);
+const scContract = (key) => Buffer.concat([u32(18), u32(1), key]);
+
+/** A #[contracttype] struct is an ScMap with symbol keys in ascending order. */
+const scMap = (entries) =>
+  Buffer.concat([
+    u32(17),
+    u32(1), // the Option<ScMap> is present
+    u32(entries.length),
+    ...entries.map(([k, v]) => Buffer.concat([scSymbol(k), v])),
+  ]);
+
+// --- fixed inputs ------------------------------------------------------------
+
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+const MSG_SENDER_KEY = Buffer.alloc(32, 0x11);
+const TARGET_KEY = Buffer.alloc(32, 0x22);
+const ATTESTER_SEED = Buffer.alloc(32, 0x33);
+
+const STATEMENT = {
+  uuid: '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+  msgValue: 1000000n,
+  encodedSigAndArgs: Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]),
+  policy: 'x-golden-vector-policy',
+  expiration: 1767225600n, // 2026-01-01T00:00:00Z
+};
+
+// --- derive ------------------------------------------------------------------
+
+const networkId = crypto.createHash('sha256').update(NETWORK_PASSPHRASE).digest();
+
+const statementXdr = scMap([
+  ['encoded_sig_and_args', scBytes(STATEMENT.encodedSigAndArgs)],
+  ['expiration', scU64(STATEMENT.expiration)],
+  ['msg_sender', scAccount(MSG_SENDER_KEY)],
+  ['msg_value', scI128(STATEMENT.msgValue)],
+  ['policy', scString(STATEMENT.policy)],
+  ['target', scContract(TARGET_KEY)],
+  ['uuid', scString(STATEMENT.uuid)],
+]);
+
+const preimage = Buffer.concat([scBytes(networkId), statementXdr]);
+const digest = crypto.createHash('sha256').update(preimage).digest();
+
+// The attester signs the 32-byte digest directly; the contract passes it to
+// ed25519_verify unhashed.
+const privateKey = crypto.createPrivateKey({
+  key: Buffer.concat([
+    Buffer.from('302e020100300506032b657004220420', 'hex'), // PKCS#8 Ed25519 seed prefix
+    ATTESTER_SEED,
+  ]),
+  format: 'der',
+  type: 'pkcs8',
+});
+const publicKey = crypto.createPublicKey(privateKey);
+const attesterPk = publicKey.export({ format: 'der', type: 'spki' }).subarray(12);
+const signature = crypto.sign(null, digest, privateKey);
+
+if (!crypto.verify(null, digest, publicKey, signature)) {
+  throw new Error('self-check failed: signature does not verify over the digest');
+}
+
+// --- output ------------------------------------------------------------------
+
+console.log(`network passphrase   ${NETWORK_PASSPHRASE}`);
+console.log(`GV_NETWORK_ID        ${networkId.toString('hex')}`);
+console.log(`GV_MSG_SENDER        ${strkey(VERSION_BYTE_ACCOUNT, MSG_SENDER_KEY)}`);
+console.log(`GV_TARGET            ${strkey(VERSION_BYTE_CONTRACT, TARGET_KEY)}`);
+console.log(`GV_UUID              ${STATEMENT.uuid}`);
+console.log(`GV_POLICY            ${STATEMENT.policy}`);
+console.log(`GV_MSG_VALUE         ${STATEMENT.msgValue}`);
+console.log(`GV_EXPIRATION        ${STATEMENT.expiration}`);
+console.log(`preimage             ${preimage.length} bytes`);
+console.log(`GV_DIGEST            ${digest.toString('hex')}`);
+console.log(`GV_ATTESTER_PK       ${attesterPk.toString('hex')}`);
+console.log(`GV_SIGNATURE         ${signature.toString('hex')}`);

--- a/soroban/scripts/verify-golden-vector-detects-drift.sh
+++ b/soroban/scripts/verify-golden-vector-detects-drift.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates that the golden-vector tests detect wire-format changes, by making
+# each change and confirming they fail.
+#
+# The concern this answers: the rest of the digest tests ask the contract for a
+# hash and then sign what they got back, so they pass under any format change.
+# Asserting that the golden tests "would catch it" is worth no more than the
+# other tests were — so run it.
+#
+#   ./soroban/scripts/verify-golden-vector-detects-drift.sh
+#
+# Each mutation is applied to a real source file, `cargo test` is run, and the
+# file is restored. Sources are copied aside first and restored by an EXIT trap,
+# so an interrupted run does not leave the tree modified. Uncommitted work is
+# safe — nothing here touches git.
+#
+# Deliberately not wired into CI: it rewrites tracked sources and runs the suite
+# once per mutation. `golden-vector.js --check` is the CI-side guard, and it
+# covers the failure this cannot — a pinned constant quietly updated to match
+# whatever the code now produces.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+REGISTRY_LIB="predicate-registry/src/lib.rs"
+VALIDATION="predicate-registry/src/validation.rs"
+TYPES="predicate-registry/src/types.rs"
+
+BACKUP="$(mktemp -d)"
+cp "$REGISTRY_LIB" "$BACKUP/lib.rs"
+cp "$VALIDATION" "$BACKUP/validation.rs"
+cp "$TYPES" "$BACKUP/types.rs"
+
+restore() {
+  cp "$BACKUP/lib.rs" "$REGISTRY_LIB"
+  cp "$BACKUP/validation.rs" "$VALIDATION"
+  cp "$BACKUP/types.rs" "$TYPES"
+  rm -rf "$BACKUP"
+}
+trap restore EXIT
+
+failures=0
+
+# Rewrites a file, erroring out if the pattern did not match. A mutation that
+# silently fails to apply would make this script report success while testing
+# nothing — the same trap the golden vector exists to close.
+apply() {
+  local file="$1" from="$2" to="$3"
+  python3 - "$file" "$from" "$to" <<'PY'
+import pathlib, sys
+path, old, new = sys.argv[1], sys.argv[2], sys.argv[3]
+p = pathlib.Path(path)
+s = p.read_text()
+if old not in s:
+    sys.exit(f"mutation did not apply to {path}: pattern not found:\n{old}")
+p.write_text(s.replace(old, new))
+PY
+}
+
+# Asserts the golden tests fail, and that they are the only ones that do.
+expect_golden_failure() {
+  local label="$1"
+  local output
+  output="$(cargo test -p predicate-registry --lib 2>&1 || true)"
+
+  local golden_failed=0 others_failed=0
+  grep -qE '^test test::test_golden_vector_(digest|signature) \.\.\. FAILED' \
+    <<<"$output" && golden_failed=1
+  grep -E '\.\.\. FAILED' <<<"$output" | grep -qv 'test_golden_vector_' && others_failed=1
+
+  if [ "$golden_failed" -eq 1 ]; then
+    printf '  PASS  golden vector rejected it'
+    [ "$others_failed" -eq 1 ] && printf ' (other tests failed too)'
+    printf '\n'
+  else
+    printf '  FAIL  %s slipped through the golden vector\n' "$label"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "Baseline: the suite is green before any mutation."
+if ! cargo test -p predicate-registry --lib >/dev/null 2>&1; then
+  echo "  FAIL  suite is already failing; fix that before trusting this script" >&2
+  exit 1
+fi
+echo "  PASS"
+echo
+
+echo "1. Swap the two appends in compute_hash (reorders the preimage)."
+apply "$VALIDATION" \
+  '    payload.append(&e.ledger().network_id().to_xdr(e));
+    // Statement fields in deterministic order
+    payload.append(&statement.clone().to_xdr(e));' \
+  '    payload.append(&statement.clone().to_xdr(e));
+    payload.append(&e.ledger().network_id().to_xdr(e));'
+expect_golden_failure "reordered preimage"
+cp "$BACKUP/validation.rs" "$VALIDATION"
+echo
+
+echo "2. Rename a Statement field (#[contracttype] hashes field names as map keys)."
+apply "$TYPES" 'encoded_sig_and_args' 'encoded_sig_and_arg'
+apply "$REGISTRY_LIB" 'encoded_sig_and_args' 'encoded_sig_and_arg'
+expect_golden_failure "renamed field"
+cp "$BACKUP/types.rs" "$TYPES"
+cp "$BACKUP/lib.rs" "$REGISTRY_LIB"
+echo
+
+if [ "$failures" -ne 0 ]; then
+  echo "$failures mutation(s) went undetected — the golden vector is not doing its job." >&2
+  exit 1
+fi
+echo "Both wire-format changes were detected."

--- a/soroban/test-stablecoin/src/lib.rs
+++ b/soroban/test-stablecoin/src/lib.rs
@@ -123,7 +123,7 @@ mod test {
 
     use super::*;
 
-    fn setup(e: &Env) -> (Address, Address, Address, TestStablecoinContractClient) {
+    fn setup(e: &Env) -> (Address, Address, Address, TestStablecoinContractClient<'_>) {
         e.mock_all_auths();
         let admin = Address::generate(e);
         let manager = Address::generate(e);


### PR DESCRIPTION
Audit finding **FIND-001** — *Attestation digest is not bound to the host chain or registry instance* (Low).

## The problem

`compute_hash` took the domain separator as a parameter:

```rust
pub fn compute_hash(e: &Env, statement: &Statement, network: &String) -> BytesN<32> {
    payload.append(&network.clone().to_xdr(e));   // caller-supplied
    payload.append(&statement.clone().to_xdr(e));
    ...
```

Whoever called `hash_statement` / `validate_attestation` chose the domain the attester's signature was verified against. The digest was not bound to the chain executing the contract, so one valid signature could pass in domains the attester never bound. This does not let anyone forge signatures — a registered attester's signature and `caller.require_auth()` are still required.

The EVM registry has never had this hole: `hashStatementWithExpiry` and `hashStatementSafe` both mix in `block.chainid` (`src/PredicateRegistry.sol:187,213`). This brings Soroban to parity.

## The fix

Read the domain from the host:

```
sha256( XDR(ScVal::Bytes(ledger.network_id)) ++ XDR(statement) )
```

`network_id` is `sha256(network_passphrase)`. It is no longer a parameter, so there is nothing for a caller to choose. (`e.ledger().network_passphrase()` does not exist in soroban-sdk 23.5.3, as the audit notes — `network_id()` at `ledger.rs:102` is the available primitive.)

## Two deliberate deviations from the recommended remediation

**1. No version tag.** The audit suggested adding `"PredicateRegistry:v1"`. XDR already makes layouts unconfusable, so a tag would only restate what the encoding guarantees:

| | first 4 bytes | |
|---|---|---|
| old preimage | `0000000e` | `ScVal::String` (passphrase) |
| new preimage | `0000000d` | `ScVal::Bytes` (network_id) |

Nothing signed for the old layout validates under the new one, or vice versa, without a tag saying so. The same holds for future changes: a statement is an `ScVal::Map` (`00000011`) and an address an `ScVal::Address` (`00000012`), so appending or reordering fields cannot yield a byte string valid under two layouts. Cross-chain replay against Solana's ed25519 digests would require a hash collision, not domain separation — Solana's own tag earns its place because its digest is raw byte concatenation with no type information, which XDR is not. Set against zero security benefit, a tag is one more constant that two codebases must keep byte-identical forever.

**2. No registry address.** Also recommended, also omitted:

- **Cross-instance replay is already constrained.** `validate` substitutes the caller for `statement.target`, so exploiting it needs one integrating contract wired to two registries of the same preimage layout.
- **It would push a new requirement onto every attester.** The API builds this digest locally from the chain id alone (`predicate-avs` → `stmapiv2/internal/domain/types.go`, `stellarDigestBytes`); `Task` carries no registry field. Adding the address means new config plumbing to protect a configuration we do not run.
- **No other chain binds it.** EVM includes no `address(this)` and no EIP-712 domain separator; Solana's digest binds neither program id nor chain id.
- **Only one registry per network is deployed**, and v1 is deprecated.

`compute_hash` documents both decisions and the trigger to revisit the address.

## Breaking changes

The redundant `network` parameter is gone throughout:

- `hash_statement(statement)` — was `(statement, network)`
- `validate_attestation(statement, attestation, caller)` — was `(statement, attestation, network, caller)`
- `predicate_client::authorize_transaction` drops `network`
- `example-compliant-token`: the `network` constructor arg and its `NETWORK` instance-storage entry are removed (dead once the registry derives the network itself)
- `deploy-compliant-token.sh`: drops the constructor's network argument

## Rollout — requires coordination

1. **The registry upgrade and the API signing change must ship together.** There is no version negotiation; attestations signed under the old layout stop validating the moment the registry is upgraded.
2. **API change** in `stellarDigestBytes` — one line. Replace the passphrase ScVal with the network id; nothing is prepended:
   ```go
   netID := sha256.Sum256([]byte(networkPassphrase))
   netIDXDR, err := stellarBytesScVal(netID[:]).MarshalBinary()
   // payload = netIDXDR ++ statementXDR
   ```
   `stellarStatementScVal` and its map ordering are untouched — the golden-vector test just needs its expected digest regenerated.
3. **The example tokens must be redeployed, not re-pointed** — `REGISTRY` is constructor-only with no setter, and the constructor signature changed. That is also the moment nothing references the deprecated v1 registry anymore.

## Tests

46 pass; `cargo fmt --check` clean; `cargo doc` warning-free; both `wasm32-unknown-unknown` and `wasm32v1-none` build.

Two new cases pin the network binding — the digest changes under `set_network_id`, and an attestation signed on one network is rejected on another. Both were verified to fail when the `network_id` line is removed, so they are not vacuous.

Signature-rejection tests now assert on `Error(Crypto, InvalidInput)` instead of a bare `#[should_panic]`. A bare one also swallows assertion failures — the first draft of these tests passed against the *unfixed* code for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)