### PR TITLE
docs(soroban): make the registry's trust boundary explicit (FIND-002)

### DIFF
--- a/soroban/example-compliant-token/src/lib.rs
+++ b/soroban/example-compliant-token/src/lib.rs
@@ -372,7 +372,7 @@ mod test {
     /// send tokens to a *different* recipient. This guards the fix that binds
     /// `to` into the signed call data.
     #[test]
-    #[should_panic] // ed25519_verify fails: signed digest bound `bob`, not `carol`
+    #[should_panic(expected = "Error(Crypto, InvalidInput)")] // signed digest bound `bob`, not `carol`
     fn test_transfer_redirected_recipient_rejected() {
         let e = Env::default();
         e.mock_all_auths();
@@ -423,6 +423,63 @@ mod test {
 
         // Attacker (Alice) tries to redirect the approved attestation to CAROL.
         token.transfer(&alice, &carol, &transfer_amount, &attestation);
+    }
+
+    /// The companion to the recipient test, for the amount. `transfer` derives
+    /// both `msg_value` and `encoded_sig_and_args` from its live `amount`, so an
+    /// attestation approved for one amount cannot be spent at another — the case
+    /// an integration would re-open by forwarding a user-supplied amount into the
+    /// statement instead of rebuilding it (audit FIND-002).
+    #[test]
+    #[should_panic(expected = "Error(Crypto, InvalidInput)")] // signed digest bound 250, not 100
+    fn test_transfer_tampered_amount_rejected() {
+        let e = Env::default();
+        e.mock_all_auths();
+
+        let policy_id = String::from_str(&e, "x-example-policy");
+
+        let registry_owner = Address::generate(&e);
+        let registry_addr = e.register(PredicateRegistryContract, (registry_owner.clone(),));
+        let registry_client =
+            predicate_registry::PredicateRegistryContractClient::new(&e, &registry_addr);
+
+        let (attester_sk, attester_pk) = generate_ed25519_keypair(&e);
+        registry_client.register_attester(&registry_owner, &attester_pk);
+
+        let admin = Address::generate(&e);
+        let token_addr = e.register(
+            CompliantTokenContract,
+            (admin.clone(), registry_addr.clone(), policy_id.clone()),
+        );
+        let token = CompliantTokenContractClient::new(&e, &token_addr);
+
+        let alice = Address::generate(&e);
+        let bob = Address::generate(&e);
+        token.mint(&alice, &1000);
+
+        // Attester approves a transfer of 250.
+        let approved_amount: i128 = 250;
+        let statement = Statement {
+            uuid: String::from_str(&e, "transfer-amount"),
+            msg_sender: alice.clone(),
+            target: token_addr.clone(),
+            msg_value: approved_amount,
+            encoded_sig_and_args: encode_transfer_call(&e, &alice, &bob, approved_amount),
+            policy: policy_id.clone(),
+            expiration: e.ledger().timestamp() + 600,
+        };
+        let hash = registry_client.hash_statement(&statement);
+        let attestation = Attestation {
+            uuid: statement.uuid.clone(),
+            expiration: statement.expiration,
+            attester: attester_pk,
+            signature: sign_hash(&e, &attester_sk, &hash),
+        };
+
+        // Alice reuses it for a different amount. 100 is within her balance and
+        // passes the token's own checks, so the rejection can only come from the
+        // registry failing to verify the rebuilt digest.
+        token.transfer(&alice, &bob, &100, &attestation);
     }
 
     #[test]

--- a/soroban/predicate-client/src/lib.rs
+++ b/soroban/predicate-client/src/lib.rs
@@ -62,24 +62,38 @@ pub enum RegistryError {
 /// never returns `Ok(false)`, so there is no boolean outcome for the caller to
 /// branch on — a returning call means the transaction was authorized.
 ///
+/// # Every argument must come from the live call
+///
+/// This helper exists to put the registry's trust boundary somewhere hard to get
+/// wrong. The registry establishes only `target` (from the authenticated caller)
+/// and the network (from the ledger) on its own; every other statement field is
+/// taken on trust. So a returning call means "an attester signed the statement
+/// built from these arguments" — which authorizes the action actually executing
+/// only if the arguments describe it.
+///
+/// Derive each one from the function you are protecting, never from a parameter an
+/// end user can choose. Forwarding user-supplied values here validates one action
+/// while executing another, with no signature forgery involved.
+///
 /// # Arguments
 /// * `e` - Soroban environment
 /// * `registry` - Address of the deployed PredicateRegistry contract
 /// * `attestation` - The signed attestation from an authorized attester
-/// * `encoded_sig_and_args` - Encoded function call data (variable-length)
-/// * `msg_sender` - The original caller
-/// * `msg_value` - Value sent with the transaction (token amount, equivalent to EVM msg.value)
+/// * `encoded_sig_and_args` - Encoding of the *concrete* call: selector plus every
+///   argument that matters for compliance. Omitting an argument leaves it free to
+///   change between attestation and execution — see `encode_transfer_call` in
+///   `example-compliant-token`, and the tampered-recipient/amount tests that pin it
+/// * `msg_sender` - The live sender, already `require_auth()`ed by the caller
+/// * `msg_value` - The live value (token amount, equivalent to EVM msg.value)
 /// * `target` - The contract being called — callers should pass `e.current_contract_address()`
 ///   so that the registry's hashStatementSafe logic can bind the attestation to this contract
-/// * `policy` - The policy ID for this contract
+/// * `policy` - This contract's configured policy, read from its own storage
 ///
-/// Domain separation (network and registry instance) is derived by the registry
-/// from the ledger, so there is nothing for the integrator to configure or get
-/// wrong here.
+/// Domain separation (the network) is derived by the registry from the ledger, so
+/// there is nothing for the integrator to configure or get wrong here.
 // The argument list mirrors the Statement fields on purpose. Collapsing it into a
 // params struct would make it natural to build one value and reuse it across
-// calls, and every field here has to be re-derived from the call being
-// authorized — a stale field authorizes an action other than the one executing.
+// calls, which is exactly what the section above rules out.
 #[allow(clippy::too_many_arguments)]
 pub fn authorize_transaction(
     e: &Env,

--- a/soroban/predicate-registry/src/lib.rs
+++ b/soroban/predicate-registry/src/lib.rs
@@ -1,4 +1,35 @@
 #![no_std]
+//! Predicate Registry — verifies attester-signed [`Statement`]s for integrating
+//! contracts.
+//!
+//! # Trust boundary
+//!
+//! The registry verifies that a registered attester signed the statement it was
+//! handed. It cannot see the call it is authorizing: the live function selector,
+//! arguments, sender, and amount all belong to the integrating contract, which is
+//! a separate invocation. Only two fields are established independently of what
+//! the caller passes:
+//!
+//! * `target` — replaced with the authenticated `caller` before hashing, so an
+//!   attestation is bound to the contract presenting it (hashStatementSafe).
+//! * the network — read from the ledger, never a parameter (see
+//!   `validation::compute_hash`).
+//!
+//! Every remaining field (`msg_sender`, `msg_value`, `encoded_sig_and_args`,
+//! `policy`) is taken on trust. **Integrating contracts must derive them from the
+//! call currently executing, never from values an end user supplies.** A contract
+//! that forwards user-controlled statement fields will validate an attestation
+//! for one action and then execute a different one — the signature check passes
+//! because the attester really did sign the statement it was shown; it just is not
+//! the statement describing what happens next.
+//!
+//! Use [`predicate_client::authorize_transaction`] rather than calling
+//! [`PredicateRegistryContract::validate_attestation`] directly. It builds the
+//! statement from its arguments, which keeps the live-data requirement at the
+//! integrating function's signature where it is hard to get wrong. See
+//! `example-compliant-token` for a worked integration.
+//!
+//! [`predicate_client::authorize_transaction`]: https://github.com/predicatelabs/predicate-contracts/blob/main/soroban/predicate-client/src/lib.rs
 
 mod attesters;
 mod policy;
@@ -139,6 +170,28 @@ impl PredicateRegistryContract {
     /// it replaces `statement.target` with the actual caller address before
     /// verifying the signature, preventing cross-contract replay attacks.
     /// In Soroban, the calling contract should pass `e.current_contract_address()`.
+    /// `caller.require_auth()` makes that binding sound — a contract address
+    /// cannot be impersonated by whoever assembled the transaction.
+    ///
+    /// # The caller owns the statement's accuracy
+    ///
+    /// `statement` is trusted input apart from `target`. A returning call means
+    /// "a registered attester signed *this* statement", not "the action you are
+    /// about to take is approved" — those coincide only when the caller built the
+    /// statement from the call it is executing:
+    ///
+    /// * `uuid` / `expiration` — copy from the attestation (both are cross-checked)
+    /// * `msg_sender`, `msg_value` — the live sender and amount, after
+    ///   `require_auth()` on the sender
+    /// * `encoded_sig_and_args` — an encoding of the *concrete* call, covering every
+    ///   argument that matters for compliance, so no argument can be swapped between
+    ///   attestation and execution
+    /// * `policy` — the contract's own configured policy, from its storage
+    ///
+    /// Passing any of these straight through from a user-supplied parameter is an
+    /// authorization bypass in the integrating contract. Prefer
+    /// `predicate_client::authorize_transaction`, which takes these as arguments
+    /// and assembles the statement itself. See the crate-level trust boundary docs.
     pub fn validate_attestation(
         e: &Env,
         statement: Statement,


### PR DESCRIPTION
Rebased onto main after #69 merged. Also corrects a doc line that #69 left stale — predicate-client claimed the registry instance was part of the digest’s domain separation, which it isn’t.
